### PR TITLE
Add shell parameter to subprocess calls

### DIFF
--- a/cloudknot/__init__.py
+++ b/cloudknot/__init__.py
@@ -17,9 +17,13 @@ from .dockerimage import *  # noqa
 from .version import __version__  # noqa
 
 try:
+    is_windows = (os.name == 'nt')
     fnull = open(os.devnull, "w")
     subprocess.check_call(
-        "docker version", shell=True, stdout=fnull, stderr=subprocess.STDOUT
+        "docker version",
+        shell=is_windows,
+        stdout=fnull,
+        stderr=subprocess.STDOUT
     )
 except subprocess.CalledProcessError:
     raise ImportError(

--- a/cloudknot/__init__.py
+++ b/cloudknot/__init__.py
@@ -17,13 +17,9 @@ from .dockerimage import *  # noqa
 from .version import __version__  # noqa
 
 try:
-    is_windows = (os.name == 'nt')
     fnull = open(os.devnull, "w")
     subprocess.check_call(
-        "docker version",
-        shell=is_windows,
-        stdout=fnull,
-        stderr=subprocess.STDOUT
+        "docker version", shell=True, stdout=fnull, stderr=subprocess.STDOUT
     )
 except subprocess.CalledProcessError:
     raise ImportError(

--- a/cloudknot/commands/configure.py
+++ b/cloudknot/commands/configure.py
@@ -22,6 +22,7 @@ from ..config import add_resource
 module_logger = logging.getLogger(__name__)
 is_windows = (os.name == 'nt')
 
+
 def pull_and_push_base_images(region, profile, ecr_repo):
     # Use docker low-level APIClient for tagging
     c = docker.from_env().api

--- a/cloudknot/commands/configure.py
+++ b/cloudknot/commands/configure.py
@@ -20,7 +20,7 @@ from ..aws import (
 from ..config import add_resource
 
 module_logger = logging.getLogger(__name__)
-
+is_windows = (os.name == 'nt')
 
 def pull_and_push_base_images(region, profile, ecr_repo):
     # Use docker low-level APIClient for tagging
@@ -50,12 +50,12 @@ def pull_and_push_base_images(region, profile, ecr_repo):
         cmd = ["aws", "ecr", "get-login", "--no-include-email", "--region", region]
 
     # Refresh the aws ecr login credentials
-    login_cmd = subprocess.check_output(cmd)
+    login_cmd = subprocess.check_output(cmd, shell=is_windows)
 
     # Login
     login_cmd = login_cmd.decode("ASCII").rstrip("\n").split(" ")
     fnull = open(os.devnull, "w")
-    subprocess.call(login_cmd, stdout=fnull, stderr=subprocess.STDOUT)
+    subprocess.call(login_cmd, stdout=fnull, stderr=subprocess.STDOUT, shell=is_windows)
 
     repo = DockerRepo(name=ecr_repo)
 
@@ -87,7 +87,7 @@ class Configure(Base):
             "please follow the prompts to start using cloudknot.\n"
         )
 
-        subprocess.call("aws configure".split(" "))
+        subprocess.call("aws configure".split(" "), shell=is_windows)
 
         print(
             "\n`aws configure` complete. Resuming configuration with "

--- a/cloudknot/dockerimage.py
+++ b/cloudknot/dockerimage.py
@@ -36,6 +36,7 @@ def registered(fn):
 mod_logger = logging.getLogger(__name__)
 is_windows = (os.name == 'nt')
 
+
 # noinspection PyPropertyAccess,PyAttributeOutsideInit
 @registered
 class DockerImage(aws.NamedObject):

--- a/cloudknot/dockerimage.py
+++ b/cloudknot/dockerimage.py
@@ -34,7 +34,7 @@ def registered(fn):
 
 
 mod_logger = logging.getLogger(__name__)
-
+is_windows = (os.name == 'nt')
 
 # noinspection PyPropertyAccess,PyAttributeOutsideInit
 @registered

--- a/cloudknot/dockerimage.py
+++ b/cloudknot/dockerimage.py
@@ -691,7 +691,7 @@ class DockerImage(aws.NamedObject):
         else:
             # Then we're actually doing this thing. Use the Docker CLI
             # Refresh the aws ecr login credentials
-            login_cmd = subprocess.check_output(cmd)
+            login_cmd = subprocess.check_output(cmd, shell=is_windows)
 
             # Login
             login_cmd_list = login_cmd.decode("ASCII").rstrip("\n").split(" ")


### PR DESCRIPTION
In order to run on windows, shell must be set to true for most subprocess calls