### PR TITLE
Make resource tagging more consistent

### DIFF
--- a/cloudknot/aws/base_classes.py
+++ b/cloudknot/aws/base_classes.py
@@ -318,7 +318,7 @@ def set_s3_params(bucket, policy=None, sse=None):
                 raise e
 
         # Add the cloudknot tags to the bucket
-        clients.put_bucket_tagging(
+        clients["s3"].put_bucket_tagging(
             Bucket=bucket,
             Tagging={'TagSet': get_tags(bucket)}
         )

--- a/cloudknot/aws/base_classes.py
+++ b/cloudknot/aws/base_classes.py
@@ -27,6 +27,15 @@ mod_logger = logging.getLogger(__name__)
 
 
 @registered
+def get_tags(name):
+    return [
+        {"Key": "Name", "Value": name},
+        {"Key": "Owner", "Value": get_user()},
+        {"Key": "Environment", "Value": "cloudknot"},
+    ]
+
+
+@registered
 def get_ecr_repo():
     """Get the cloudknot ECR repository
 
@@ -297,6 +306,12 @@ def set_s3_params(bucket, policy=None, sse=None):
             else:
                 # Pass exception to user
                 raise e
+
+        # Add the cloudknot tags to the bucket
+        clients.put_bucket_tagging(
+            Bucket=bucket,
+            Tagging={'TagSet': get_tags(bucket)}
+        )
 
         if policy is None:
             policy = "cloudknot-bucket-access-" + str(uuid.uuid4())

--- a/cloudknot/aws/ecr.py
+++ b/cloudknot/aws/ecr.py
@@ -78,10 +78,20 @@ class DockerRepo(NamedObject):
             repo_uri = response["repositories"][0]["repositoryUri"]
             repo_registry_id = response["repositories"][0]["registryId"]
 
-            clients["ecr"].tag_resource(
-                resourceArn=response["repositories"][0]["repositoryArn"],
-                tags=get_tags(self.name)
-            )
+            try:
+                clients["ecr"].tag_resource(
+                    resourceArn=response["repositories"][0]["repositoryArn"],
+                    tags=get_tags(self.name)
+                )
+            except NotImplementedError as e:
+                moto_msg = "The tag_resource action has not been implemented"
+                if moto_msg in e.args:
+                    # This exception is here for compatibility with moto
+                    # testing since the tag_resource action has not been
+                    # implemented in moto. Simply move on.
+                    pass
+                else:
+                    raise e
 
             mod_logger.info(
                 "Repository {name:s} already exists at "

--- a/cloudknot/aws/ecr.py
+++ b/cloudknot/aws/ecr.py
@@ -68,55 +68,33 @@ class DockerRepo(NamedObject):
         RepoInfo : namedtuple
             a namedtuple with fields name, uri, and registry_id
         """
+        # Flake8 will see that repo_arn is set in the try/except clauses
+        # and claim that we are referencing it before assignment below
+        # so we predefine it here. Also, it should be predefined as a
+        # string to pass parameter validation by boto.
+        repo_arn = "test"
         try:
             # If repo exists, retrieve its info
             response = clients["ecr"].describe_repositories(
                 repositoryNames=[self.name]
             )
 
+            repo_arn = response["repositories"][0]["repositoryArn"]
             repo_name = response["repositories"][0]["repositoryName"]
             repo_uri = response["repositories"][0]["repositoryUri"]
             repo_registry_id = response["repositories"][0]["registryId"]
-
-            try:
-                clients["ecr"].tag_resource(
-                    resourceArn=response["repositories"][0]["repositoryArn"],
-                    tags=get_tags(self.name)
-                )
-            except NotImplementedError as e:
-                moto_msg = "The tag_resource action has not been implemented"
-                if moto_msg in e.args:
-                    # This exception is here for compatibility with moto
-                    # testing since the tag_resource action has not been
-                    # implemented in moto. Simply move on.
-                    pass
-                else:
-                    raise e
-
-            mod_logger.info(
-                "Repository {name:s} already exists at "
-                "{uri:s}".format(name=self.name, uri=repo_uri)
-            )
+            repo_created = False
         except clients["ecr"].exceptions.RepositoryNotFoundException:
             # If it doesn't exists already, then create it
             response = clients["ecr"].create_repository(
                 repositoryName=self.name
             )
 
+            repo_arn = response["repository"]["repositoryArn"]
             repo_name = response["repository"]["repositoryName"]
             repo_uri = response["repository"]["repositoryUri"]
             repo_registry_id = response["repository"]["registryId"]
-
-            clients["ecr"].tag_resource(
-                resourceArn=response["repository"]["repositoryArn"],
-                tags=get_tags(self.name)
-            )
-
-            mod_logger.info(
-                "Created repository {name:s} at {uri:s}".format(
-                    name=self.name, uri=repo_uri
-                )
-            )
+            repo_created = True
         except botocore.exceptions.ClientError as e:
             error_code = e.response["Error"]["Code"]
             message = e.response["Error"]["Message"]
@@ -127,15 +105,38 @@ class DockerRepo(NamedObject):
                 # If it doesn't exists already, then create it
                 response = clients["ecr"].create_repository(repositoryName=self.name)
 
+                repo_arn = response["repository"]["repositoryArn"]
                 repo_name = response["repository"]["repositoryName"]
                 repo_uri = response["repository"]["repositoryUri"]
                 repo_registry_id = response["repository"]["registryId"]
+                repo_created = True
 
-                mod_logger.info(
-                    "Created repository {name:s} at {uri:s}".format(
-                        name=self.name, uri=repo_uri
-                    )
+        if repo_created:
+            mod_logger.info(
+                "Created repository {name:s} at {uri:s}".format(
+                    name=self.name, uri=repo_uri
                 )
+            )
+        else:
+            mod_logger.info(
+                "Repository {name:s} already exists at "
+                "{uri:s}".format(name=self.name, uri=repo_uri)
+            )
+
+        try:
+            clients["ecr"].tag_resource(
+                resourceArn=repo_arn,
+                tags=get_tags(self.name)
+            )
+        except NotImplementedError as e:
+            moto_msg = "The tag_resource action has not been implemented"
+            if moto_msg in e.args:
+                # This exception is here for compatibility with moto
+                # testing since the tag_resource action has not been
+                # implemented in moto. Simply move on.
+                pass
+            else:
+                raise e
 
         # Define and return namedtuple with repo info
         RepoInfo = namedtuple("RepoInfo", ["name", "uri", "registry_id"])

--- a/cloudknot/cloudknot.py
+++ b/cloudknot/cloudknot.py
@@ -1518,6 +1518,9 @@ class Knot(aws.NamedObject):
                 {"ParameterKey": "CeName", "ParameterValue": compute_environment_name},
                 {"ParameterKey": "CeResourceType", "ParameterValue": resource_type},
                 {"ParameterKey": "CeMinvCpus", "ParameterValue": str(min_vcpus)},
+                {"ParameterKey": "CeTagNameValue", "ParameterValue": self.name},
+                {"ParameterKey": "CeTagOwnerValue", "ParameterValue": aws.get_user()},
+                {"ParameterKey": "CeTagEnvironmentValue", "ParameterValue": "cloudknot"},
                 {
                     "ParameterKey": "CeDesiredvCpus",
                     "ParameterValue": str(desired_vcpus),

--- a/cloudknot/cloudknot.py
+++ b/cloudknot/cloudknot.py
@@ -440,11 +440,7 @@ class Pars(aws.NamedObject):
                         },
                     ],
                     Capabilities=["CAPABILITY_NAMED_IAM"],
-                    Tags=[
-                        {"Key": "Name", "Value": self.name},
-                        {"Key": "Owner", "Value": aws.get_user()},
-                        {"Key": "Environment", "Value": "cloudknot"},
-                    ],
+                    Tags=aws.get_tags(self.name),
                 )
 
                 self._stack_id = response["StackId"]
@@ -552,11 +548,7 @@ class Pars(aws.NamedObject):
                         },
                     ],
                     Capabilities=["CAPABILITY_NAMED_IAM"],
-                    Tags=[
-                        {"Key": "Name", "Value": self.name},
-                        {"Key": "Owner", "Value": aws.get_user()},
-                        {"Key": "Environment", "Value": "cloudknot"},
-                    ],
+                    Tags=aws.get_tags(self.name),
                 )
 
                 self._stack_id = response["StackId"]
@@ -1567,11 +1559,7 @@ class Knot(aws.NamedObject):
                 TemplateBody=template_body,
                 Parameters=params,
                 Capabilities=["CAPABILITY_NAMED_IAM"],
-                Tags=[
-                    {"Key": "Name", "Value": self.name},
-                    {"Key": "Owner", "Value": aws.get_user()},
-                    {"Key": "Environment", "Value": "cloudknot"},
-                ],
+                Tags=aws.get_tags(self.name),
             )
 
             self._stack_id = response["StackId"]

--- a/cloudknot/templates/batch-environment.template
+++ b/cloudknot/templates/batch-environment.template
@@ -108,6 +108,19 @@
                 "Default" : "optimal",
                 "Description" : "Instance types that may be launched in the compute environment. Default='optimal'"
             },
+            "CeTagNameValue" : {
+                "Type" : "String",
+                "Description" : "Tags are key-value pairs to be applied to resources that are launched in the compute environment. This parameter specifies the value associated with the Name key."
+            },
+            "CeTagOwnerValue" : {
+                "Type" : "String",
+                "Description" : "Tags are key-value pairs to be applied to resources that are launched in the compute environment. This parameter specifies the value associated with the Owner key."
+            },
+            "CeTagEnvironmentValue" : {
+                "Type" : "String",
+                "Description" : "Tags are key-value pairs to be applied to resources that are launched in the compute environment. This parameter specifies the value associated with the Environment key.",
+                "Default" : "cloudknot"
+            },
             "CeBidPercentage" : {
                 "Type" : "Number",
                 "Default" : "50",
@@ -224,6 +237,11 @@
                                 { "Ref" : "AWS::NoValue" }
                             ]
                         },
+                        "Tags" : {
+                            "Name": { "Ref": "CeTagNameValue" },
+                            "Owner": { "Ref": "CeTagOwnerValue" },
+                            "Environment": { "Ref": "CeTagEnvironmentValue" }
+                        }
                     },
                     "ServiceRole" : { "Fn::ImportValue" : { "Fn::Sub" : "${ParsStackName}-BatchServiceRole" }},
                     "State" : "ENABLED"


### PR DESCRIPTION
Resolves #146.

It seems that one cannot assign tags to IAM policies. So that is left of the list from #146. But this PR adds consistent tagging to
- EC2 resources launched in the Batch compute environment
- ECR repos
- S3 buckets