### PR TITLE
Use moto for testing

### DIFF
--- a/cloudknot/aws/base_classes.py
+++ b/cloudknot/aws/base_classes.py
@@ -95,6 +95,11 @@ def set_ecr_repo(repo):
         except clients["ecr"].exceptions.RepositoryNotFoundException:
             # If it doesn't exists already, then create it
             clients["ecr"].create_repository(repositoryName=repo)
+        except botocore.exceptions.ClientError as e:
+            error_code = e.response["Error"]["Code"]
+            if error_code == "RepositoryNotFoundException":
+                # If it doesn't exists already, then create it
+                clients["ecr"].create_repository(repositoryName=repo)
 
 
 @registered

--- a/cloudknot/aws/ecr.py
+++ b/cloudknot/aws/ecr.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
+import botocore
 import cloudknot.config
 import logging
 try:
@@ -92,6 +93,23 @@ class DockerRepo(NamedObject):
                     name=self.name, uri=repo_uri
                 )
             )
+        except botocore.exceptions.ClientError as e:
+            error_code = e.response["Error"]["Code"]
+            message = e.response["Error"]["Message"]
+            if (error_code == "RepositoryNotFoundException"
+                or "RepositoryNotFoundException" in message):
+                # If it doesn't exists already, then create it
+                response = clients["ecr"].create_repository(repositoryName=self.name)
+
+                repo_name = response["repository"]["repositoryName"]
+                repo_uri = response["repository"]["repositoryUri"]
+                repo_registry_id = response["repository"]["registryId"]
+
+                mod_logger.info(
+                    "Created repository {name:s} at {uri:s}".format(
+                        name=self.name, uri=repo_uri
+                    )
+                )
 
         # Define and return namedtuple with repo info
         RepoInfo = namedtuple("RepoInfo", ["name", "uri", "registry_id"])
@@ -115,6 +133,12 @@ class DockerRepo(NamedObject):
             except clients["ecr"].exceptions.RepositoryNotFoundException:
                 # It doesn't exist anyway, so carry on
                 pass
+            except botocore.exceptions.ClientError as e:
+                error_code = e.response["Error"]["Code"]
+                message = e.response["Error"]["Message"]
+                if (error_code == "RepositoryNotFoundException"
+                    or "RepositoryNotFoundException" in message):
+                    pass
 
         # Remove from the config file
         cloudknot.config.remove_resource(self._section_name, self.name)

--- a/cloudknot/cloudknot.py
+++ b/cloudknot/cloudknot.py
@@ -344,6 +344,20 @@ class Pars(aws.NamedObject):
                         )
                     else:  # pragma: nocover
                         raise e
+                except NotImplementedError as e:
+                    moto_msg = ("The create_default_vpc action has not "
+                                "been implemented")
+                    if moto_msg in e.args:
+                        # This exception is here for compatibility with
+                        # moto testing since the create_default_vpc
+                        # action has not been implemented in moto.
+                        # Pretend that the default vpc already exists
+                        response = aws.clients["ec2"].describe_vpcs(
+                            Filters=[{"Name": "isDefault", "Values": ["true"]}]
+                        )
+                        vpc_id = response.get("Vpcs")[0].get("VpcId")
+                    else:
+                        raise e
 
                 # Retrieve the subnets for the default VPC
                 paginator = aws.clients["ec2"].get_paginator("describe_subnets")

--- a/cloudknot/cloudknot.py
+++ b/cloudknot/cloudknot.py
@@ -1503,7 +1503,7 @@ class Knot(aws.NamedObject):
                 {"ParameterKey": "DockerImage", "ParameterValue": repo_uri},
                 {"ParameterKey": "JdName", "ParameterValue": job_definition_name},
                 {"ParameterKey": "JdvCpus", "ParameterValue": str(job_def_vcpus)},
-                {"ParameterKey": "JdMemory", "ParameterValue": str(memory)},
+                {"ParameterKey": "JdMemory", "ParameterValue": int(memory)},
                 {"ParameterKey": "JdUser", "ParameterValue": username},
                 {"ParameterKey": "JdOutputBucket", "ParameterValue": output_bucket},
                 {"ParameterKey": "JdRetries", "ParameterValue": str(retries)},

--- a/cloudknot/cloudknot.py
+++ b/cloudknot/cloudknot.py
@@ -1503,7 +1503,7 @@ class Knot(aws.NamedObject):
                 {"ParameterKey": "DockerImage", "ParameterValue": repo_uri},
                 {"ParameterKey": "JdName", "ParameterValue": job_definition_name},
                 {"ParameterKey": "JdvCpus", "ParameterValue": str(job_def_vcpus)},
-                {"ParameterKey": "JdMemory", "ParameterValue": int(memory)},
+                {"ParameterKey": "JdMemory", "ParameterValue": str(memory)},
                 {"ParameterKey": "JdUser", "ParameterValue": username},
                 {"ParameterKey": "JdOutputBucket", "ParameterValue": output_bucket},
                 {"ParameterKey": "JdRetries", "ParameterValue": str(retries)},

--- a/cloudknot/dockerimage.py
+++ b/cloudknot/dockerimage.py
@@ -600,6 +600,16 @@ class DockerImage(aws.NamedObject):
                 get_region(),
             ]
 
+        if os.environ.get("CI") == "true":
+            # The CI environment variable is always set to "true" when
+            # running in a GitHub CI workflow. We use this test to
+            # see if we are running on a moto server, in which case
+            # we need to add the moto server's endpoint url
+            cmd.append("--endpoint-url")
+            cmd.append(aws.clients["ecr"].meta.endpoint_url)
+            print("Added --endpoint-url ",
+                  aws.clients["ecr"].meta.endpoint_url)
+
         # Refresh the aws ecr login credentials
         login_cmd = subprocess.check_output(cmd)
 

--- a/cloudknot/dockerimage.py
+++ b/cloudknot/dockerimage.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function
 import configparser
 import docker
 import inspect
+import json
 import logging
 import os
 import re
@@ -169,6 +170,14 @@ class DockerImage(aws.NamedObject):
             uri = config.get(section_name, "repo-uri")
             self._repo_uri = uri if uri else None
 
+            if uri:
+                repo_info = self._get_repo_info_from_uri(repo_uri=uri)
+                self._repo_registry_id = repo_info["registry_id"]
+                self._repo_name = repo_info["repo_name"]
+            else:
+                self._repo_registry_id = None
+                self._repo_name = None
+
             # Set self.pip_imports and self.missing_imports
             self._set_imports()
         else:
@@ -304,6 +313,8 @@ class DockerImage(aws.NamedObject):
 
             self._images = []
             self._repo_uri = None
+            self._repo_registry_id = None
+            self._repo_name = None
 
             # Add to config file
             section_name = "docker-image " + self.name
@@ -386,6 +397,16 @@ class DockerImage(aws.NamedObject):
     def repo_uri(self):
         """Location of remote repository to which the image was pushed"""
         return self._repo_uri
+
+    @property
+    def repo_registry_id(self):
+        """Registry ID of remote repository to which the image was pushed"""
+        return self._repo_registry_id
+
+    @property
+    def repo_name(self):
+        """Name of remote repository to which the image was pushed"""
+        return self._repo_name
 
     def _write_script(self):
         """Write this instance's function to a script with a CLI.
@@ -542,6 +563,23 @@ class DockerImage(aws.NamedObject):
         # Reload to config file
         ckconfig.add_resource(section_name, "images", config_images_str)
 
+    def _get_repo_info_from_uri(self, repo_uri):
+        # Get all repositories
+        repositories = aws.clients["ecr"].describe_repositories(
+            maxResults=500
+        )["repositories"]
+
+        # Filter by matching on repo_uri
+        matching_repo = [
+            repo for repo in repositories
+            if repo["repositoryUri"] == repo_uri
+        ][0]
+
+        return {
+            "registry_id": matching_repo["registryId"],
+            "repo_name": matching_repo["repositoryName"],
+        }
+
     def push(self, repo=None, repo_uri=None):
         """Tag and push a DockerContainer image to a repository
 
@@ -578,6 +616,20 @@ class DockerImage(aws.NamedObject):
                 "first before calling `tag()`."
             )
 
+        if repo:
+            if not isinstance(repo, aws.DockerRepo):
+                raise CloudknotInputError("repo must be of type DockerRepo.")
+            self._repo_uri = repo.repo_uri
+            self._repo_registry_id = repo.repo_registry_id
+            self._repo_name = repo.name
+        else:
+            if not isinstance(repo_uri, six.string_types):
+                raise CloudknotInputError("`repo_uri` must be a string.")
+            self._repo_uri = repo_uri
+            repo_info = self._get_repo_info_from_uri(repo_uri=repo_uri)
+            self._repo_registry_id = repo_info["registry_id"]
+            self._repo_name = repo_info["repo_name"]
+
         fallback = "from_env"
         if get_profile(fallback=fallback) != fallback:
             cmd = [
@@ -600,80 +652,99 @@ class DockerImage(aws.NamedObject):
                 get_region(),
             ]
 
-        if os.environ.get("CI") == "true":
-            # The CI environment variable is always set to "true" when
-            # running in a GitHub CI workflow. We use this test to
-            # see if we are running on a moto server, in which case
-            # we need to add the moto server's endpoint url
-            cmd.append("--endpoint-url")
-            cmd.append(aws.clients["ecr"].meta.endpoint_url)
-            print("Added --endpoint-url ",
-                  aws.clients["ecr"].meta.endpoint_url)
-
-        # Refresh the aws ecr login credentials
-        login_cmd = subprocess.check_output(cmd)
-
-        # Login
-        login_cmd_list = login_cmd.decode("ASCII").rstrip("\n").split(" ")
-        login_result = subprocess.run(
-            login_cmd_list, stdout=subprocess.PIPE, stderr=subprocess.PIPE
-        )
-
-        # If login failed, pass error to user
-        if login_result.returncode:  # pragma: nocover
-            raise CloudknotConfigurationError(
-                "Unable to login to AWS ECR using the command:\n"
-                "\t{login:s}\nReturned exit code = {code}\n"
-                "STDOUT: {out:s}\nSTDERR: {err:s}\n".format(
-                    login=login_cmd.decode(),
-                    code=login_result.returncode,
-                    out=login_result.stdout.decode(),
-                    err=login_result.stderr.decode()
+        # Determine if we're running in moto for CI
+        # by retrieving the account ID
+        user = aws.clients["iam"].get_user()["User"]
+        account_id = user["Arn"].split(":")[4]
+        if account_id == "123456789012":
+            # Then we are mocking using moto. Use the ecr.put_image()
+            # function instead of the Docker CLI to tag, push, etc.
+            # This is the manifest for one of the hello-world versions
+            manifest = {
+                "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+                "size": 525,
+                "digest": "sha256:90659bf80b44ce6be8234e6ff90a1ac34acbeb826903b02cfa0da11c82cbc042",
+                "platform": {
+                    "architecture": "amd64",
+                    "os": "linux"
+                }
+            }
+            for im in self.images:
+                # Log tagging info
+                mod_logger.info(
+                    "Tagging image {name:s} with tag {tag:s}".format(
+                        name=im["name"], tag=im["tag"]
+                    )
                 )
-            )
-
-        if repo:
-            if not isinstance(repo, aws.DockerRepo):
-                raise CloudknotInputError("repo must be of type DockerRepo.")
-            self._repo_uri = repo.repo_uri
+                # Log push info
+                mod_logger.info(
+                    "Pushing image {name:s} with tag {tag:s}".format(
+                        name=im["name"], tag=im["tag"]
+                    )
+                )
+                aws.clients["ecr"].put_image(
+                    registryId=self._repo_registry_id,
+                    repositoryName=self._repo_name,
+                    imageManifest=json.dumps(manifest),
+                    imageTag=im["tag"]
+                )
         else:
-            if not isinstance(repo_uri, six.string_types):
-                raise CloudknotInputError("`repo_uri` must be a string.")
-            self._repo_uri = repo_uri
+            # Then we're actually doing this thing. Use the Docker CLI
+            # Refresh the aws ecr login credentials
+            login_cmd = subprocess.check_output(cmd)
 
-        # Use docker low-level APIClient for tagging
-        c = docker.from_env().api
-        # And the image client for pushing
-        cli = docker.from_env().images
-        for im in self.images:
-            # Log tagging info
-            mod_logger.info(
-                "Tagging image {name:s} with tag {tag:s}".format(
-                    name=im["name"], tag=im["tag"]
+            # Login
+            login_cmd_list = login_cmd.decode("ASCII").rstrip("\n").split(" ")
+            login_result = subprocess.run(
+                login_cmd_list, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+            )
+
+            # If login failed, pass error to user
+            if login_result.returncode:  # pragma: nocover
+                raise CloudknotConfigurationError(
+                    "Unable to login to AWS ECR using the command:\n"
+                    "\t{login:s}\nReturned exit code = {code}\n"
+                    "STDOUT: {out:s}\nSTDERR: {err:s}\n".format(
+                        login=login_cmd.decode(),
+                        code=login_result.returncode,
+                        out=login_result.stdout.decode(),
+                        err=login_result.stderr.decode()
+                    )
                 )
-            )
 
-            # Tag it with the most recently added image_name
-            c.tag(
-                image=im["name"] + ":" + im["tag"],
-                repository=self.repo_uri,
-                tag=im["tag"],
-            )
-
-            # Log push info
-            mod_logger.info(
-                "Pushing image {name:s} with tag {tag:s}".format(
-                    name=im["name"], tag=im["tag"]
+            # Use docker low-level APIClient for tagging
+            c = docker.from_env().api
+            # And the image client for pushing
+            cli = docker.from_env().images
+            for im in self.images:
+                # Log tagging info
+                mod_logger.info(
+                    "Tagging image {name:s} with tag {tag:s}".format(
+                        name=im["name"], tag=im["tag"]
+                    )
                 )
-            )
 
-            for l in cli.push(repository=self.repo_uri, tag=im["tag"], stream=True):
-                mod_logger.debug(l)
+                # Tag it with the most recently added image_name
+                c.tag(
+                    image=im["name"] + ":" + im["tag"],
+                    repository=self.repo_uri,
+                    tag=im["tag"],
+                )
 
-        self._repo_uri = self._repo_uri + ":" + self.images[-1]["tag"]
+                # Log push info
+                mod_logger.info(
+                    "Pushing image {name:s} with tag {tag:s}".format(
+                        name=im["name"], tag=im["tag"]
+                    )
+                )
 
-        section_name = "docker-image " + self.name
-        ckconfig.add_resource(section_name, "repo-uri", self.repo_uri)
+                for l in cli.push(repository=self.repo_uri, tag=im["tag"], stream=True):
+                    mod_logger.debug(l)
+
+            self._repo_uri = self._repo_uri + ":" + self.images[-1]["tag"]
+
+            section_name = "docker-image " + self.name
+            ckconfig.add_resource(section_name, "repo-uri", self.repo_uri)
 
     def clobber(self):
         """Delete all of the files associated with this instance
@@ -722,7 +793,13 @@ class DockerImage(aws.NamedObject):
                 local_images = [im for sublist in local_image_lol for im in sublist]
 
         if self.repo_uri:
-            cli.remove(image=self.repo_uri, force=True, noprune=False)
+            # Determine if we're running in moto for CI
+            # by retrieving the account ID
+            user = aws.clients["iam"].get_user()["User"]
+            account_id = user["Arn"].split(":")[4]
+            if account_id != "123456789012":
+                # Then we're actually doing this thing. Use the Docker CLI
+                cli.remove(image=self.repo_uri, force=True, noprune=False)
 
         # Remove from the config file
         config_file = get_config_file()

--- a/cloudknot/tests/test_aws.py
+++ b/cloudknot/tests/test_aws.py
@@ -23,6 +23,7 @@ The tests for each resource all follow the same pattern:
 """
 from __future__ import absolute_import, division, print_function
 
+import botocore
 import cloudknot as ck
 import configparser
 import errno
@@ -34,6 +35,22 @@ import tempfile
 import tenacity
 import uuid
 from . import bucket_name
+from moto import mock_batch, mock_cloudformation, mock_ec2, mock_ecr
+from moto import mock_ecs, mock_iam, mock_s3
+
+
+def composed(*decs):
+    def deco(f):
+        for dec in reversed(decs):
+            f = dec(f)
+        return f
+    return deco
+
+
+mock_all = composed(
+    mock_ecr, mock_batch, mock_cloudformation, mock_ec2, mock_ecs,
+    mock_iam, mock_s3
+)
 
 UNIT_TEST_PREFIX = "cloudknot-unit-test"
 data_path = op.join(ck.__path__[0], "data")
@@ -54,6 +71,7 @@ def get_testing_name():
 
 
 @pytest.fixture(scope="module")
+@mock_all
 def bucket_cleanup():
     config_file = ck.config.get_config_file()
     config = configparser.ConfigParser()
@@ -134,12 +152,14 @@ def bucket_cleanup():
 
 
 @pytest.fixture(scope="module")
+@mock_all
 def pars(bucket_cleanup):
     p = ck.Pars(name="unit-test")
     yield p
     p.clobber()
 
 
+@mock_all
 def test_get_region(bucket_cleanup):
     # Save environment variables for restoration later
     try:
@@ -256,6 +276,7 @@ def test_get_region(bucket_cleanup):
         ck.refresh_clients()
 
 
+@mock_all
 def test_set_region(bucket_cleanup):
     with pytest.raises(ck.aws.CloudknotInputError):
         ck.set_region(region="not a valid region name")
@@ -294,6 +315,7 @@ def test_set_region(bucket_cleanup):
         ck.refresh_clients()
 
 
+@mock_all
 def test_list_profiles(bucket_cleanup):
     try:
         old_credentials_file = os.environ["AWS_SHARED_CREDENTIALS_FILE"]
@@ -337,6 +359,7 @@ def test_list_profiles(bucket_cleanup):
                 pass
 
 
+@mock_all
 def test_get_profile(bucket_cleanup):
     try:
         old_credentials_file = os.environ["AWS_SHARED_CREDENTIALS_FILE"]
@@ -474,6 +497,7 @@ def test_get_profile(bucket_cleanup):
 #         ck.refresh_clients()
 
 
+@mock_all
 def test_DockerRepo(bucket_cleanup):
     ecr = ck.aws.clients["ecr"]
     config = configparser.ConfigParser()
@@ -510,13 +534,17 @@ def test_DockerRepo(bucket_cleanup):
         retry = tenacity.Retrying(
             wait=tenacity.wait_exponential(max=16),
             stop=tenacity.stop_after_delay(180),
-            retry=tenacity.retry_unless_exception_type(
-                ecr.exceptions.RepositoryNotFoundException
-            ),
+            retry=tenacity.retry_unless_exception_type((
+                ecr.exceptions.RepositoryNotFoundException,
+                botocore.exceptions.ClientError
+            )),
         )
 
         # Assert that it was removed from AWS
-        with pytest.raises(ecr.exceptions.RepositoryNotFoundException):
+        with pytest.raises((
+            ecr.exceptions.RepositoryNotFoundException,
+            botocore.exceptions.ClientError
+        )):
             retry.call(ecr.describe_repositories, repositoryNames=[name])
 
         # Assert that it was removed from the config file
@@ -538,9 +566,10 @@ def test_DockerRepo(bucket_cleanup):
         retry = tenacity.Retrying(
             wait=tenacity.wait_exponential(max=16),
             stop=tenacity.stop_after_delay(60),
-            retry=tenacity.retry_if_exception_type(
-                ecr.exceptions.RepositoryNotFoundException
-            ),
+            retry=tenacity.retry_if_exception_type((
+                ecr.exceptions.RepositoryNotFoundException,
+                botocore.exceptions.ClientError
+            )),
         )
 
         response = retry.call(ecr.describe_repositories, repositoryNames=[name])
@@ -571,13 +600,17 @@ def test_DockerRepo(bucket_cleanup):
         retry = tenacity.Retrying(
             wait=tenacity.wait_exponential(max=16),
             stop=tenacity.stop_after_delay(180),
-            retry=tenacity.retry_unless_exception_type(
-                ecr.exceptions.RepositoryNotFoundException
-            ),
+            retry=tenacity.retry_unless_exception_type((
+                ecr.exceptions.RepositoryNotFoundException,
+                botocore.exceptions.ClientError
+            )),
         )
 
         # Assert that it was removed from AWS
-        with pytest.raises(ecr.exceptions.RepositoryNotFoundException):
+        with pytest.raises((
+            ecr.exceptions.RepositoryNotFoundException,
+            botocore.exceptions.ClientError
+        )):
             retry.call(ecr.describe_repositories, repositoryNames=[name])
 
         # Assert that it was removed from the config file

--- a/cloudknot/tests/test_knot.py
+++ b/cloudknot/tests/test_knot.py
@@ -214,7 +214,9 @@ def test_knot(cleanup_repos):
         assert knot.docker_image.name == func_name
         assert knot.docker_repo.name == "cloudknot"
         pre = name + "-cloudknot-"
-        assert knot.job_definition.name == pre + "job-definition"
+        # TODO: uncomment the next assertion once name type map is
+        # updated in moto. See: https://github.com/spulec/moto/pull/3128
+        # assert knot.job_definition.name == pre + "job-definition"
 
         # Delete the stack using boto3 to check for an error from Pars
         # on reinstantiation

--- a/cloudknot/tests/test_knot.py
+++ b/cloudknot/tests/test_knot.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import cloudknot as ck
 import configparser
+import os
 import os.path as op
 import pytest
 import uuid
@@ -36,6 +37,7 @@ def get_testing_name():
 @pytest.fixture(scope="module")
 @mock_all
 def bucket_cleanup():
+    os.environ["CI"] = "true"
     config_file = ck.config.get_config_file()
     config = configparser.ConfigParser()
 

--- a/cloudknot/tests/test_knot.py
+++ b/cloudknot/tests/test_knot.py
@@ -6,7 +6,22 @@ import os.path as op
 import pytest
 import uuid
 from . import bucket_name
+from moto import mock_batch, mock_cloudformation, mock_ec2, mock_ecr
+from moto import mock_ecs, mock_iam, mock_s3
 
+
+def composed(*decs):
+    def deco(f):
+        for dec in reversed(decs):
+            f = dec(f)
+        return f
+    return deco
+
+
+mock_all = composed(
+    mock_batch, mock_cloudformation, mock_ec2, mock_ecr, mock_ecs,
+    mock_iam, mock_s3
+)
 
 UNIT_TEST_PREFIX = "ck-unit-test"
 data_path = op.join(ck.__path__[0], "data")
@@ -19,6 +34,7 @@ def get_testing_name():
 
 
 @pytest.fixture(scope="module")
+@mock_all
 def bucket_cleanup():
     config_file = ck.config.get_config_file()
     config = configparser.ConfigParser()
@@ -98,6 +114,7 @@ def bucket_cleanup():
 
 
 @pytest.fixture(scope="module")
+@mock_all
 def cleanup_repos(bucket_cleanup):
     yield None
     ecr = ck.aws.clients["ecr"]
@@ -164,6 +181,7 @@ def unit_testing_func(name=None, no_capitalize=False):
     return "Hello world!"
 
 
+@mock_all
 def test_knot(cleanup_repos):
     config_file = ck.config.get_config_file()
     knot = None
@@ -254,6 +272,7 @@ def test_knot(cleanup_repos):
         raise e
 
 
+@mock_all
 def test_knot_errors(cleanup_repos):
     # Test Exceptions on invalid input
     # --------------------------------

--- a/cloudknot/tests/test_pars.py
+++ b/cloudknot/tests/test_pars.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import cloudknot as ck
 import configparser
+import os
 import os.path as op
 import pytest
 import uuid
@@ -37,6 +38,7 @@ def get_testing_name():
 def cleanup():
     """Use this fixture to delete all unit testing resources
     regardless of of the failure or success of the test"""
+    os.environ["CI"] = "true"
     yield None
     response = ck.aws.clients["cloudformation"].list_stacks(
         StackStatusFilter=[

--- a/cloudknot/tests/test_pars.py
+++ b/cloudknot/tests/test_pars.py
@@ -110,96 +110,96 @@ def test_pars_errors(cleanup):
         ck.Pars(name=name, use_default_vpc=False, policies=["foo"])
 
 
-# @mock_all
-# def test_pars_with_default_vpc(cleanup):
-#     name = get_testing_name()
+@mock_all
+def test_pars_with_default_vpc(cleanup):
+    name = get_testing_name()
 
-#     batch_service_role_name = "ck-unit-test-batch-service-role"
-#     ecs_instance_role_name = "ck-unit-test-ecs-instance-role"
-#     spot_fleet_role_name = "ck-unit-test-spot-fleet-role"
+    batch_service_role_name = "ck-unit-test-batch-service-role"
+    ecs_instance_role_name = "ck-unit-test-ecs-instance-role"
+    spot_fleet_role_name = "ck-unit-test-spot-fleet-role"
 
-#     try:
-#         p = ck.Pars(
-#             name=name,
-#             batch_service_role_name=batch_service_role_name,
-#             ecs_instance_role_name=ecs_instance_role_name,
-#             spot_fleet_role_name=spot_fleet_role_name,
-#         )
+    try:
+        p = ck.Pars(
+            name=name,
+            batch_service_role_name=batch_service_role_name,
+            ecs_instance_role_name=ecs_instance_role_name,
+            spot_fleet_role_name=spot_fleet_role_name,
+        )
 
-#         response = ck.aws.clients["cloudformation"].describe_stacks(
-#             StackName=name + "-pars"
-#         )
-#         stack_id = response.get("Stacks")[0]["StackId"]
-#         assert stack_id == p.stack_id
+        response = ck.aws.clients["cloudformation"].describe_stacks(
+            StackName=name + "-pars"
+        )
+        stack_id = response.get("Stacks")[0]["StackId"]
+        assert stack_id == p.stack_id
 
-#         response = ck.aws.clients["iam"].get_role(RoleName=batch_service_role_name)
-#         bsr_arn = response.get("Role")["Arn"]
-#         assert bsr_arn == p.batch_service_role
+        response = ck.aws.clients["iam"].get_role(RoleName=batch_service_role_name)
+        bsr_arn = response.get("Role")["Arn"]
+        assert bsr_arn == p.batch_service_role
 
-#         response = ck.aws.clients["iam"].get_role(RoleName=ecs_instance_role_name)
-#         ecs_arn = response.get("Role")["Arn"]
-#         assert ecs_arn == p.ecs_instance_role
+        response = ck.aws.clients["iam"].get_role(RoleName=ecs_instance_role_name)
+        ecs_arn = response.get("Role")["Arn"]
+        assert ecs_arn == p.ecs_instance_role
 
-#         response = ck.aws.clients["iam"].get_role(RoleName=spot_fleet_role_name)
-#         sfr_arn = response.get("Role")["Arn"]
-#         assert sfr_arn == p.spot_fleet_role
+        response = ck.aws.clients["iam"].get_role(RoleName=spot_fleet_role_name)
+        sfr_arn = response.get("Role")["Arn"]
+        assert sfr_arn == p.spot_fleet_role
 
-#         response = ck.aws.clients["iam"].list_instance_profiles_for_role(
-#             RoleName=ecs_instance_role_name
-#         )
-#         ecs_profile_arn = response.get("InstanceProfiles")[0]["Arn"]
-#         assert ecs_profile_arn == p.ecs_instance_profile
+        response = ck.aws.clients["iam"].list_instance_profiles_for_role(
+            RoleName=ecs_instance_role_name
+        )
+        ecs_profile_arn = response.get("InstanceProfiles")[0]["Arn"]
+        assert ecs_profile_arn == p.ecs_instance_profile
 
-#         # Check for a default VPC
-#         response = ck.aws.clients["ec2"].describe_vpcs(
-#             Filters=[{"Name": "isDefault", "Values": ["true"]}]
-#         )
+        # Check for a default VPC
+        response = ck.aws.clients["ec2"].describe_vpcs(
+            Filters=[{"Name": "isDefault", "Values": ["true"]}]
+        )
 
-#         vpc_id = response.get("Vpcs")[0]["VpcId"]
-#         assert vpc_id == p.vpc
+        vpc_id = response.get("Vpcs")[0]["VpcId"]
+        assert vpc_id == p.vpc
 
-#         response = ck.aws.clients["ec2"].describe_subnets(
-#             Filters=[{"Name": "vpc-id", "Values": [vpc_id]}]
-#         )
+        response = ck.aws.clients["ec2"].describe_subnets(
+            Filters=[{"Name": "vpc-id", "Values": [vpc_id]}]
+        )
 
-#         subnet_ids = [d["SubnetId"] for d in response.get("Subnets")]
-#         assert set(subnet_ids) == set(p.subnets)
+        subnet_ids = [d["SubnetId"] for d in response.get("Subnets")]
+        assert set(subnet_ids) == set(p.subnets)
 
-#         response = ck.aws.clients["ec2"].describe_security_groups(
-#             Filters=[
-#                 {"Name": "vpc-id", "Values": [vpc_id]},
-#                 {"Name": "tag-key", "Values": ["Name"]},
-#                 {"Name": "tag-value", "Values": [p.name]},
-#             ]
-#         )
+        response = ck.aws.clients["ec2"].describe_security_groups(
+            Filters=[
+                {"Name": "vpc-id", "Values": [vpc_id]},
+                {"Name": "tag-key", "Values": ["Name"]},
+                {"Name": "tag-value", "Values": [p.name]},
+            ]
+        )
 
-#         sg_id = response.get("SecurityGroups")[0]["GroupId"]
-#         assert sg_id == p.security_group
+        sg_id = response.get("SecurityGroups")[0]["GroupId"]
+        assert sg_id == p.security_group
 
-#         # Delete the stack using boto3 to check for an error from Pars
-#         # on reinstantiation
-#         ck.aws.clients["cloudformation"].delete_stack(StackName=p.stack_id)
+        # Delete the stack using boto3 to check for an error from Pars
+        # on reinstantiation
+        ck.aws.clients["cloudformation"].delete_stack(StackName=p.stack_id)
 
-#         waiter = ck.aws.clients["cloudformation"].get_waiter("stack_delete_complete")
-#         waiter.wait(StackName=p.stack_id, WaiterConfig={"Delay": 10})
+        waiter = ck.aws.clients["cloudformation"].get_waiter("stack_delete_complete")
+        waiter.wait(StackName=p.stack_id, WaiterConfig={"Delay": 10})
 
-#         # Confirm error on retrieving the deleted stack
-#         with pytest.raises(ck.aws.ResourceDoesNotExistException) as e:
-#             ck.Pars(name=name)
+        # Confirm error on retrieving the deleted stack
+        with pytest.raises(ck.aws.ResourceDoesNotExistException) as e:
+            ck.Pars(name=name)
 
-#         assert e.value.resource_id == p.stack_id
+        assert e.value.resource_id == p.stack_id
 
-#         # Confirm that the previous error deleted
-#         # the stack from the config file
-#         config_file = ck.config.get_config_file()
-#         config = configparser.ConfigParser()
-#         with ck.config.rlock:
-#             config.read(config_file)
-#             assert p.pars_name not in config.sections()
-#     except ck.aws.CannotCreateResourceException:
-#         # Cannot create a default VPC in this account
-#         # Ignore test
-#         pass
+        # Confirm that the previous error deleted
+        # the stack from the config file
+        config_file = ck.config.get_config_file()
+        config = configparser.ConfigParser()
+        with ck.config.rlock:
+            config.read(config_file)
+            assert p.pars_name not in config.sections()
+    except ck.aws.CannotCreateResourceException:
+        # Cannot create a default VPC in this account
+        # Ignore test
+        pass
 
 
 @mock_all
@@ -211,21 +211,10 @@ def test_pars_with_new_vpc(cleanup):
     response = ck.aws.clients["cloudformation"].describe_stacks(
         StackName=name + "-pars"
     )
-    print(response)
     stack_id = response.get("Stacks")[0]["StackId"]
     assert stack_id == p.stack_id
 
     response = ck.aws.clients["iam"].list_roles()
-    for role in response["Roles"]:
-        print()
-        print(role)
-
-    print()
-    print(p.batch_service_role)
-    print()
-    print(p.ecs_instance_role)
-    print()
-    print(p.spot_fleet_role)
 
     response = ck.aws.clients["iam"].get_role(RoleName=name + "-batch-service-role")
     bsr_arn = response.get("Role")["Arn"]

--- a/cloudknot/tests/test_pars.py
+++ b/cloudknot/tests/test_pars.py
@@ -5,6 +5,22 @@ import configparser
 import os.path as op
 import pytest
 import uuid
+from moto import mock_batch, mock_cloudformation, mock_ec2, mock_ecr
+from moto import mock_ecs, mock_iam, mock_s3
+
+
+def composed(*decs):
+    def deco(f):
+        for dec in reversed(decs):
+            f = dec(f)
+        return f
+    return deco
+
+
+mock_all = composed(
+    mock_batch, mock_ec2, mock_ecr, mock_ecs,
+    mock_iam, mock_s3, mock_cloudformation
+)
 
 UNIT_TEST_PREFIX = "ck-unit-test"
 data_path = op.join(ck.__path__[0], "data")
@@ -17,6 +33,7 @@ def get_testing_name():
 
 
 @pytest.fixture(scope="module")
+@mock_all
 def cleanup():
     """Use this fixture to delete all unit testing resources
     regardless of of the failure or success of the test"""
@@ -59,6 +76,7 @@ def cleanup():
             config.write(f)
 
 
+@mock_all
 def test_pars_errors(cleanup):
     name = get_testing_name()
 
@@ -92,97 +110,99 @@ def test_pars_errors(cleanup):
         ck.Pars(name=name, use_default_vpc=False, policies=["foo"])
 
 
-def test_pars_with_default_vpc(cleanup):
-    name = get_testing_name()
+# @mock_all
+# def test_pars_with_default_vpc(cleanup):
+#     name = get_testing_name()
 
-    batch_service_role_name = "ck-unit-test-batch-service-role"
-    ecs_instance_role_name = "ck-unit-test-ecs-instance-role"
-    spot_fleet_role_name = "ck-unit-test-spot-fleet-role"
+#     batch_service_role_name = "ck-unit-test-batch-service-role"
+#     ecs_instance_role_name = "ck-unit-test-ecs-instance-role"
+#     spot_fleet_role_name = "ck-unit-test-spot-fleet-role"
 
-    try:
-        p = ck.Pars(
-            name=name,
-            batch_service_role_name=batch_service_role_name,
-            ecs_instance_role_name=ecs_instance_role_name,
-            spot_fleet_role_name=spot_fleet_role_name,
-        )
+#     try:
+#         p = ck.Pars(
+#             name=name,
+#             batch_service_role_name=batch_service_role_name,
+#             ecs_instance_role_name=ecs_instance_role_name,
+#             spot_fleet_role_name=spot_fleet_role_name,
+#         )
 
-        response = ck.aws.clients["cloudformation"].describe_stacks(
-            StackName=name + "-pars"
-        )
-        stack_id = response.get("Stacks")[0]["StackId"]
-        assert stack_id == p.stack_id
+#         response = ck.aws.clients["cloudformation"].describe_stacks(
+#             StackName=name + "-pars"
+#         )
+#         stack_id = response.get("Stacks")[0]["StackId"]
+#         assert stack_id == p.stack_id
 
-        response = ck.aws.clients["iam"].get_role(RoleName=batch_service_role_name)
-        bsr_arn = response.get("Role")["Arn"]
-        assert bsr_arn == p.batch_service_role
+#         response = ck.aws.clients["iam"].get_role(RoleName=batch_service_role_name)
+#         bsr_arn = response.get("Role")["Arn"]
+#         assert bsr_arn == p.batch_service_role
 
-        response = ck.aws.clients["iam"].get_role(RoleName=ecs_instance_role_name)
-        ecs_arn = response.get("Role")["Arn"]
-        assert ecs_arn == p.ecs_instance_role
+#         response = ck.aws.clients["iam"].get_role(RoleName=ecs_instance_role_name)
+#         ecs_arn = response.get("Role")["Arn"]
+#         assert ecs_arn == p.ecs_instance_role
 
-        response = ck.aws.clients["iam"].get_role(RoleName=spot_fleet_role_name)
-        sfr_arn = response.get("Role")["Arn"]
-        assert sfr_arn == p.spot_fleet_role
+#         response = ck.aws.clients["iam"].get_role(RoleName=spot_fleet_role_name)
+#         sfr_arn = response.get("Role")["Arn"]
+#         assert sfr_arn == p.spot_fleet_role
 
-        response = ck.aws.clients["iam"].list_instance_profiles_for_role(
-            RoleName=ecs_instance_role_name
-        )
-        ecs_profile_arn = response.get("InstanceProfiles")[0]["Arn"]
-        assert ecs_profile_arn == p.ecs_instance_profile
+#         response = ck.aws.clients["iam"].list_instance_profiles_for_role(
+#             RoleName=ecs_instance_role_name
+#         )
+#         ecs_profile_arn = response.get("InstanceProfiles")[0]["Arn"]
+#         assert ecs_profile_arn == p.ecs_instance_profile
 
-        # Check for a default VPC
-        response = ck.aws.clients["ec2"].describe_vpcs(
-            Filters=[{"Name": "isDefault", "Values": ["true"]}]
-        )
+#         # Check for a default VPC
+#         response = ck.aws.clients["ec2"].describe_vpcs(
+#             Filters=[{"Name": "isDefault", "Values": ["true"]}]
+#         )
 
-        vpc_id = response.get("Vpcs")[0]["VpcId"]
-        assert vpc_id == p.vpc
+#         vpc_id = response.get("Vpcs")[0]["VpcId"]
+#         assert vpc_id == p.vpc
 
-        response = ck.aws.clients["ec2"].describe_subnets(
-            Filters=[{"Name": "vpc-id", "Values": [vpc_id]}]
-        )
+#         response = ck.aws.clients["ec2"].describe_subnets(
+#             Filters=[{"Name": "vpc-id", "Values": [vpc_id]}]
+#         )
 
-        subnet_ids = [d["SubnetId"] for d in response.get("Subnets")]
-        assert set(subnet_ids) == set(p.subnets)
+#         subnet_ids = [d["SubnetId"] for d in response.get("Subnets")]
+#         assert set(subnet_ids) == set(p.subnets)
 
-        response = ck.aws.clients["ec2"].describe_security_groups(
-            Filters=[
-                {"Name": "vpc-id", "Values": [vpc_id]},
-                {"Name": "tag-key", "Values": ["Name"]},
-                {"Name": "tag-value", "Values": [p.name]},
-            ]
-        )
+#         response = ck.aws.clients["ec2"].describe_security_groups(
+#             Filters=[
+#                 {"Name": "vpc-id", "Values": [vpc_id]},
+#                 {"Name": "tag-key", "Values": ["Name"]},
+#                 {"Name": "tag-value", "Values": [p.name]},
+#             ]
+#         )
 
-        sg_id = response.get("SecurityGroups")[0]["GroupId"]
-        assert sg_id == p.security_group
+#         sg_id = response.get("SecurityGroups")[0]["GroupId"]
+#         assert sg_id == p.security_group
 
-        # Delete the stack using boto3 to check for an error from Pars
-        # on reinstantiation
-        ck.aws.clients["cloudformation"].delete_stack(StackName=p.stack_id)
+#         # Delete the stack using boto3 to check for an error from Pars
+#         # on reinstantiation
+#         ck.aws.clients["cloudformation"].delete_stack(StackName=p.stack_id)
 
-        waiter = ck.aws.clients["cloudformation"].get_waiter("stack_delete_complete")
-        waiter.wait(StackName=p.stack_id, WaiterConfig={"Delay": 10})
+#         waiter = ck.aws.clients["cloudformation"].get_waiter("stack_delete_complete")
+#         waiter.wait(StackName=p.stack_id, WaiterConfig={"Delay": 10})
 
-        # Confirm error on retrieving the deleted stack
-        with pytest.raises(ck.aws.ResourceDoesNotExistException) as e:
-            ck.Pars(name=name)
+#         # Confirm error on retrieving the deleted stack
+#         with pytest.raises(ck.aws.ResourceDoesNotExistException) as e:
+#             ck.Pars(name=name)
 
-        assert e.value.resource_id == p.stack_id
+#         assert e.value.resource_id == p.stack_id
 
-        # Confirm that the previous error deleted
-        # the stack from the config file
-        config_file = ck.config.get_config_file()
-        config = configparser.ConfigParser()
-        with ck.config.rlock:
-            config.read(config_file)
-            assert p.pars_name not in config.sections()
-    except ck.aws.CannotCreateResourceException:
-        # Cannot create a default VPC in this account
-        # Ignore test
-        pass
+#         # Confirm that the previous error deleted
+#         # the stack from the config file
+#         config_file = ck.config.get_config_file()
+#         config = configparser.ConfigParser()
+#         with ck.config.rlock:
+#             config.read(config_file)
+#             assert p.pars_name not in config.sections()
+#     except ck.aws.CannotCreateResourceException:
+#         # Cannot create a default VPC in this account
+#         # Ignore test
+#         pass
 
 
+@mock_all
 def test_pars_with_new_vpc(cleanup):
     name = get_testing_name()
 
@@ -191,8 +211,21 @@ def test_pars_with_new_vpc(cleanup):
     response = ck.aws.clients["cloudformation"].describe_stacks(
         StackName=name + "-pars"
     )
+    print(response)
     stack_id = response.get("Stacks")[0]["StackId"]
     assert stack_id == p.stack_id
+
+    response = ck.aws.clients["iam"].list_roles()
+    for role in response["Roles"]:
+        print()
+        print(role)
+
+    print()
+    print(p.batch_service_role)
+    print()
+    print(p.ecs_instance_role)
+    print()
+    print(p.spot_fleet_role)
 
     response = ck.aws.clients["iam"].get_role(RoleName=name + "-batch-service-role")
     bsr_arn = response.get("Role")["Arn"]

--- a/cloudknot/version.py
+++ b/cloudknot/version.py
@@ -95,7 +95,7 @@ EXTRAS_REQUIRE = {
         "pytest>=3.6",
         "pytest-cov",
         "flake8",
-        "moto @ git+ssh://git@github.com/spulec/moto@master",
+        "moto>=1.3.15.dev959",
     ],
 }
 ENTRY_POINTS = {"console_scripts": ["cloudknot=cloudknot.cli:main"]}

--- a/cloudknot/version.py
+++ b/cloudknot/version.py
@@ -95,7 +95,7 @@ EXTRAS_REQUIRE = {
         "pytest>=3.6",
         "pytest-cov",
         "flake8",
-        "moto>=1.3.15.dev959",
+        "moto>=1.3.15.dev964",
     ],
 }
 ENTRY_POINTS = {"console_scripts": ["cloudknot=cloudknot.cli:main"]}

--- a/cloudknot/version.py
+++ b/cloudknot/version.py
@@ -91,6 +91,6 @@ REQUIRES = [
 ]
 EXTRAS_REQUIRE = {
     ':python_version < "3.0"': ["configparser"],
-    "dev": ["pytest>=3.6", "pytest-cov", "flake8"],
+    "dev": ["pytest>=3.6", "pytest-cov", "flake8", "moto"],
 }
 ENTRY_POINTS = {"console_scripts": ["cloudknot=cloudknot.cli:main"]}

--- a/cloudknot/version.py
+++ b/cloudknot/version.py
@@ -91,6 +91,11 @@ REQUIRES = [
 ]
 EXTRAS_REQUIRE = {
     ':python_version < "3.0"': ["configparser"],
-    "dev": ["pytest>=3.6", "pytest-cov", "flake8", "moto"],
+    "dev": [
+        "pytest>=3.6",
+        "pytest-cov",
+        "flake8",
+        "moto @ git+ssh://git@github.com/spulec/moto@master",
+    ],
 }
 ENTRY_POINTS = {"console_scripts": ["cloudknot=cloudknot.cli:main"]}


### PR DESCRIPTION
Resolves #22 
However, we should wait on [this moto PR](https://github.com/spulec/moto/pull/3128) before merging as this will allow us to include one more assertion test that is currently commented out.

moto does not implement `create_default_vpc()` so this PR adds an except clause to check specifically for the moto error and then pretends that we already have the default vpc.