### PR TITLE
Fix volume_size and PARS policies issues

### DIFF
--- a/cloudknot/cloudknot.py
+++ b/cloudknot/cloudknot.py
@@ -1192,6 +1192,14 @@ class Knot(aws.NamedObject):
                     "If you provide volume_size, you cannot specify the image_id"
                 )
 
+            if volume_size is not None:
+                if not isinstance(volume_size, int):
+                    raise aws.CloudknotInputError("volume_size must be an integer.")
+                if not volume_size > 0:
+                    raise aws.CloudknotInputError(
+                        "volume_size must be greater than zero."
+                    )
+
             # Default instance type is 'optimal'
             instance_types = instance_types if instance_types else ["optimal"]
             if isinstance(instance_types, six.string_types):
@@ -1585,7 +1593,7 @@ class Knot(aws.NamedObject):
 
             if volume_size is not None:
                 params.append(
-                    {"ParameterKey": "LtVolumeSize", "ParameterValue": volume_size}
+                    {"ParameterKey": "LtVolumeSize", "ParameterValue": str(volume_size)}
                 )
                 params.append(
                     {

--- a/cloudknot/cloudknot.py
+++ b/cloudknot/cloudknot.py
@@ -1608,7 +1608,16 @@ class Knot(aws.NamedObject):
 
                 # Set the image id to use the ECS-optimized Amazon Linux
                 # 2 image
-                response = aws.clients["ec2"].describe_images(Owners=["amazon"])
+
+                # First, determine if we're running in moto for CI
+                # by retrieving the account ID
+                user = aws.clients["iam"].get_user()["User"]
+                account_id = user["Arn"].split(":")[4]
+                if account_id == "123456789012":
+                    response = aws.clients["ec2"].describe_images()
+                else:
+                    response = aws.clients["ec2"].describe_images(Owners=["amazon"])
+
                 ecs_optimized_images = sorted(
                     [
                         image

--- a/cloudknot/cloudknot.py
+++ b/cloudknot/cloudknot.py
@@ -216,12 +216,16 @@ class Pars(aws.NamedObject):
                 "spot_fleet_role_name": (spot_fleet_role_name, self._spot_fleet_role),
                 "ipv4_cidr": (ipv4_cidr, stack_ipv4_cidr),
                 "instance_tenancy": (instance_tenancy, stack_instance_tenancy),
-                "policies": (set(policies), stack_policies),
             }
 
             conflicting_params = {
                 k: v for k, v in input_params.items() if v[0] and v[1] != v[0]
             }
+
+            # Inspect policies separately since we only require policies
+            # the input to be a subset of the stack-defined policies
+            if not set(policies) <= stack_policies:
+                conflicting_params["policies"] = (set(policies), stack_policies)
 
             if conflicting_params:
                 raise aws.CloudknotInputError(

--- a/cloudknot/templates/batch-environment-increase-ebs-volume.template
+++ b/cloudknot/templates/batch-environment-increase-ebs-volume.template
@@ -78,7 +78,7 @@
             "LtVolumeSize" : {
                 "Type" : "Number",
                 "Default" : "30",
-                "Description" : "Launch template volume size in GB"
+                "Description" : "Launch template volume size in GB",
                 "MinValue" : "1",
                 "ConstraintDescription" : "LtVolumeSize must be greater than zero."
             },
@@ -273,7 +273,7 @@
             },
             "JobDefinition": {
                 "Value" : { "Ref" : "JobDefinition" }
-            }
+            },
             "LaunchTemplate": {
                 "Value" : { "Ref" : "LaunchTemplate" }
             }

--- a/cloudknot/tests/test_aws.py
+++ b/cloudknot/tests/test_aws.py
@@ -500,6 +500,7 @@ def test_get_profile(bucket_cleanup):
 
 @mock_all
 def test_DockerRepo(bucket_cleanup):
+    ck.refresh_clients()
     ecr = ck.aws.clients["ecr"]
     config = configparser.ConfigParser()
     config_file = ck.config.get_config_file()

--- a/cloudknot/tests/test_docker_image.py
+++ b/cloudknot/tests/test_docker_image.py
@@ -192,6 +192,7 @@ def unit_testing_func(name=None, no_capitalize=False):
 
 @mock_all
 def test_DockerImage(cleanup_repos):
+    ck.refresh_clients()
     config = configparser.ConfigParser()
     config_file = ck.config.get_config_file()
     ecr = ck.aws.clients["ecr"]

--- a/cloudknot/tests/test_knot.py
+++ b/cloudknot/tests/test_knot.py
@@ -190,7 +190,7 @@ def test_knot(cleanup_repos):
     try:
         ec2 = ck.aws.clients["ec2"]
         instance = ec2.run_instances(MaxCount=1, MinCount=1)["Instances"][0]
-        image_response = ec2.create_image(
+        ec2.create_image(
             BlockDeviceMappings=[
                 {
                     "DeviceName": "/dev/xvda",

--- a/cloudknot/tests/test_knot.py
+++ b/cloudknot/tests/test_knot.py
@@ -189,7 +189,7 @@ def test_knot(cleanup_repos):
         pars = ck.Pars(name=get_testing_name(), use_default_vpc=False)
         name = get_testing_name()
 
-        knot = ck.Knot(name=name, pars=pars, func=unit_testing_func)
+        knot = ck.Knot(name=name, pars=pars, func=unit_testing_func, volume_size=42)
 
         # Now remove the images and repo-uri from the docker-image
         # Forcing the next call to Knot to rebuild and re-push the image.
@@ -344,3 +344,15 @@ def test_knot_errors(cleanup_repos):
     # Assert ck.aws.CloudknotInputError on invalid ec2_key_pair
     with pytest.raises(ck.aws.CloudknotInputError):
         ck.Knot(ec2_key_pair=42)
+
+    # Assert ck.aws.CloudknotInputError on invalid volume_size
+    with pytest.raises(ck.aws.CloudknotInputError):
+        ck.Knot(volume_size="string")
+
+    # Assert ck.aws.CloudknotInputError on volume_size < 1
+    with pytest.raises(ck.aws.CloudknotInputError):
+        ck.Knot(volume_size=0)
+
+    # Assert ck.aws.CloudknotInputError when providing both image_id and volume_size
+    with pytest.raises(ck.aws.CloudknotInputError):
+        ck.Knot(image_id="test-string", volume_size=30)

--- a/cloudknot/tests/test_pars.py
+++ b/cloudknot/tests/test_pars.py
@@ -88,6 +88,7 @@ def cleanup(aws_credentials):
 
 @mock_all
 def test_pars_errors(cleanup):
+    ck.refresh_clients()
     name = get_testing_name()
 
     # Confirm name input validation
@@ -122,6 +123,7 @@ def test_pars_errors(cleanup):
 
 @mock_all
 def test_pars_with_default_vpc(cleanup):
+    ck.refresh_clients()
     name = get_testing_name()
 
     batch_service_role_name = "ck-unit-test-batch-service-role-1"
@@ -214,6 +216,7 @@ def test_pars_with_default_vpc(cleanup):
 
 @mock_all
 def test_pars_with_new_vpc(cleanup):
+    ck.refresh_clients()
     name = get_testing_name()
 
     p = ck.Pars(name=name, use_default_vpc=False)


### PR DESCRIPTION
This PR resolves two issues created from #217 and #218. For #218, `volume_size` should be converted to a string before being passed to CloudFormation. And for #217, when comparing the pre-existing PARS with the input parameters, the supplied policies need only be a subset of the ones that exist on AWS.