### PR TITLE
Add back tags and use repo URI not image URI

### DIFF
--- a/cloudknot/dockerimage.py
+++ b/cloudknot/dockerimage.py
@@ -574,9 +574,10 @@ class DockerImage(aws.NamedObject):
             "repositories"
         ]
 
+        _repo_uri = repo_uri.split(":")[0]
         # Filter by matching on repo_uri
         matching_repo = [
-            repo for repo in repositories if repo["repositoryUri"] == repo_uri
+            repo for repo in repositories if repo["repositoryUri"] == _repo_uri
         ][0]
 
         return {

--- a/cloudknot/templates/batch-environment-increase-ebs-volume.template
+++ b/cloudknot/templates/batch-environment-increase-ebs-volume.template
@@ -122,6 +122,19 @@
                 "Default" : "optimal",
                 "Description" : "Instance types that may be launched in the compute environment. Default='optimal'"
             },
+            "CeTagNameValue" : {
+                "Type" : "String",
+                "Description" : "Tags are key-value pairs to be applied to resources that are launched in the compute environment. This parameter specifies the value associated with the Name key."
+            },
+            "CeTagOwnerValue" : {
+                "Type" : "String",
+                "Description" : "Tags are key-value pairs to be applied to resources that are launched in the compute environment. This parameter specifies the value associated with the Owner key."
+            },
+            "CeTagEnvironmentValue" : {
+                "Type" : "String",
+                "Description" : "Tags are key-value pairs to be applied to resources that are launched in the compute environment. This parameter specifies the value associated with the Environment key.",
+                "Default" : "cloudknot"
+            },
             "CeBidPercentage" : {
                 "Type" : "Number",
                 "Default" : "50",
@@ -258,6 +271,11 @@
                                 { "Ref" : "AWS::NoValue" }
                             ]
                         },
+                        "Tags" : {
+                            "Name": { "Ref": "CeTagNameValue" },
+                            "Owner": { "Ref": "CeTagOwnerValue" },
+                            "Environment": { "Ref": "CeTagEnvironmentValue" }
+                        }
                     },
                     "ServiceRole" : { "Fn::ImportValue" : { "Fn::Sub" : "${ParsStackName}-BatchServiceRole" }},
                     "State" : "ENABLED"

--- a/cloudknot/templates/batch-environment.template
+++ b/cloudknot/templates/batch-environment.template
@@ -73,7 +73,7 @@
                 "Description" : "Name of the compute environment.",
                 "MinLength" : "1",
                 "MaxLength" : "100",
-                "ConstraintDescription" : "The compute environment name must be between 1 and 50 characters"
+                "ConstraintDescription" : "The compute environment name must be between 1 and 100 characters"
             },
             "CeResourceType" : {
                 "Type" : "String",


### PR DESCRIPTION
Fixing errors left over from #220 and #218.

For #220, the alternate cloudformation template removed the compute environment tags (which was bad). This PR puts them back (which is good).

For #218, DockerImage attempts to retrieve information on an AWS ECR repo by using an image URI rather than a repo URI (which was bad). This PR switched to the repo URI (which is good).