### PR TITLE
Allow user to refresh function for existing DockerImage

### DIFF
--- a/cloudknot/data/docker_reqs_ref_data/py2/ref1/Dockerfile
+++ b/cloudknot/data/docker_reqs_ref_data/py2/ref1/Dockerfile
@@ -20,11 +20,11 @@ RUN (id -u cloudknot-user >/dev/null 2>&1 || useradd cloudknot-user) \
 
 ENV HOME /home/cloudknot-user
 
-# Copy the python script
-COPY unit-testing-func.py /home/cloudknot-user/
-
 # Set working directory
 WORKDIR /home/cloudknot-user
 
 # Set entrypoint
 ENTRYPOINT ["python", "/home/cloudknot-user/unit-testing-func.py"]
+
+# Copy the python script
+COPY unit-testing-func.py /home/cloudknot-user/

--- a/cloudknot/data/docker_reqs_ref_data/py2/ref2/Dockerfile
+++ b/cloudknot/data/docker_reqs_ref_data/py2/ref2/Dockerfile
@@ -20,11 +20,11 @@ RUN (id -u unit-test-username >/dev/null 2>&1 || useradd unit-test-username) \
 
 ENV HOME /home/unit-test-username
 
-# Copy the python script
-COPY test-func-input.py /home/unit-test-username/
-
 # Set working directory
 WORKDIR /home/unit-test-username
 
 # Set entrypoint
 ENTRYPOINT ["python", "/home/unit-test-username/test-func-input.py"]
+
+# Copy the python script
+COPY test-func-input.py /home/unit-test-username/

--- a/cloudknot/data/docker_reqs_ref_data/py3/ref1/Dockerfile
+++ b/cloudknot/data/docker_reqs_ref_data/py3/ref1/Dockerfile
@@ -20,11 +20,11 @@ RUN (id -u cloudknot-user >/dev/null 2>&1 || useradd cloudknot-user) \
 
 ENV HOME /home/cloudknot-user
 
-# Copy the python script
-COPY unit-testing-func.py /home/cloudknot-user/
-
 # Set working directory
 WORKDIR /home/cloudknot-user
 
 # Set entrypoint
 ENTRYPOINT ["python", "/home/cloudknot-user/unit-testing-func.py"]
+
+# Copy the python script
+COPY unit-testing-func.py /home/cloudknot-user/

--- a/cloudknot/data/docker_reqs_ref_data/py3/ref2/Dockerfile
+++ b/cloudknot/data/docker_reqs_ref_data/py3/ref2/Dockerfile
@@ -20,11 +20,11 @@ RUN (id -u unit-test-username >/dev/null 2>&1 || useradd unit-test-username) \
 
 ENV HOME /home/unit-test-username
 
-# Copy the python script
-COPY test-func-input.py /home/unit-test-username/
-
 # Set working directory
 WORKDIR /home/unit-test-username
 
 # Set entrypoint
 ENTRYPOINT ["python", "/home/unit-test-username/test-func-input.py"]
+
+# Copy the python script
+COPY test-func-input.py /home/unit-test-username/

--- a/cloudknot/templates/Dockerfile.template
+++ b/cloudknot/templates/Dockerfile.template
@@ -20,11 +20,11 @@ RUN (id -u ${username} >/dev/null 2>&1 || useradd ${username}) \
 
 ENV HOME /home/${username}
 
-# Copy the python script
-COPY ${script_base_name} /home/${username}/
-
 # Set working directory
 WORKDIR /home/${username}
 
 # Set entrypoint
 ENTRYPOINT ["python", "/home/${username}/${script_base_name}"]
+
+# Copy the python script
+COPY ${script_base_name} /home/${username}/

--- a/cloudknot/tests/test_docker_image.py
+++ b/cloudknot/tests/test_docker_image.py
@@ -363,6 +363,10 @@ def test_DockerImage(cleanup_repos):
 
         assert "docker-image " + di.name in config.sections()
 
+        # Assert ck.aws.CloudknotInputError on name plus other input
+        with pytest.raises(ck.aws.CloudknotInputError):
+            ck.DockerImage(name=di.name, script_path="Foo")
+
         # Clobber and confirm that it deleted all the created files
         di.clobber()
         assert not op.isfile(di.req_path)
@@ -395,10 +399,6 @@ def test_DockerImage(cleanup_repos):
         # Assert ck.aws.CloudknotInputError on no input
         with pytest.raises(ck.aws.CloudknotInputError):
             ck.DockerImage()
-
-        # Assert ck.aws.CloudknotInputError on name plus other input
-        with pytest.raises(ck.aws.CloudknotInputError):
-            ck.DockerImage(name=get_testing_name(), func=unit_testing_func)
 
         # Assert ck.aws.CloudknotInputError on non-string name input
         with pytest.raises(ck.aws.CloudknotInputError):

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -184,3 +184,11 @@ job's log on Amazon CloudWatch. You can get a URL for each job attempt's
 CloudWatch log using the
 :func:`cloudknot.BatchJob.log_urls <cloudknot.aws.BatchJob.log_urls>`
 parameter.
+
+
+Anything else
+-------------
+
+Did you run into an issue that isn't addressed here? Check out the
+:ref:`faq-label` or `open up a new issue
+<https://github.com/nrdg/cloudknot/issues>`_.


### PR DESCRIPTION
Resolves #162
Resolves #163

One common issue in cloudknot development is the requirement to update a UDF after some error on AWS. Previously, this required the user to instantiate an entirely new `DockerImage`, which was okay for small Docker images but burdensome for large ones that are encountered in some scientific workflows. This PR addresses that issue by internally updating the script for the same `DockerImage` instance. It moves script addition to the last layer of the cloudknot Docker image so that this update can be pushed to AWS ECR quickly.

For now, this requires the user to create a separate `DockerImage()` instance, which is then passed as an argument to `Knot()`. In the future, one could imagine `Knot` doing this as well so that the user doesn't have to create brand new knots after an error. However, I want to keep this PR focused on `DockerImage()` and address other resources in other issues and PRs.