### PR TITLE
Add functions to clean up the cloudknot config file

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,8 +3,8 @@ branch = True
 source = cloudknot/*
 include = cloudknot/*
 omit = */setup.py
+    cloudknot/commands/*.py
     cloudknot/due.py
-    cloudknot/config.py
     cloudknot/version.py
     cloudknot/_meta.py
     cloudknot/data/*/*/*.py

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -40,6 +40,7 @@ jobs:
           coveralls
         env:
           COVERALLS_PARALLEL: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
 
   finish:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -41,7 +41,6 @@ jobs:
         env:
           COVERALLS_PARALLEL: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
 
   finish:
     needs: build

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           github-token: ${{ secrets.github_token }}
           flag-name: run-${{ matrix.python-version }}
-          path-to-lcov: ./.coverage
+          path-to-lcov: .coverage
           parallel: true
 
   finish:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -34,9 +34,8 @@ jobs:
       - name: Test
         run: |
           make test
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+      - name: Run codacy-coverage-reporter
+        uses: codacy/codacy-coverage-reporter-action@master
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          file: .coverage
-          name: codecov-cloudknot
+          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+          coverage-reports: .coverage

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -34,8 +34,20 @@ jobs:
       - name: Test
         run: |
           make test
-      - name: Run codacy-coverage-reporter
-        uses: codacy/codacy-coverage-reporter-action@master
+      - name: Coveralls Parallel
+        uses: coverallsapp/github-action@master
         with:
-          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-          coverage-reports: .coverage
+          github-token: ${{ secrets.github_token }}
+          flag-name: run-${{ matrix.python-version }}
+          path-to-lcov: ./.coverage
+          parallel: true
+
+  finish:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Coveralls Finished
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.github_token }}
+          parallel-finished: true

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -19,6 +19,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install software
         run: |
+          python -m pip install coveralls --use-feature=2020-resolver
           python -m pip install --upgrade pip --use-feature=2020-resolver
           python -m pip install .[dev] --use-feature=2020-resolver
       - name: Configure
@@ -35,12 +36,11 @@ jobs:
         run: |
           make test
       - name: Coveralls Parallel
-        uses: coverallsapp/github-action@master
-        with:
-          github-token: ${{ secrets.github_token }}
-          flag-name: run-${{ matrix.python-version }}
-          path-to-lcov: .coverage
-          parallel: true
+        run: |
+          coveralls
+        env:
+          COVERALLS_PARALLEL: true
+          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
 
   finish:
     needs: build
@@ -49,5 +49,5 @@ jobs:
       - name: Coveralls Finished
         uses: coverallsapp/github-action@master
         with:
-          github-token: ${{ secrets.github_token }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel-finished: true

--- a/Makefile
+++ b/Makefile
@@ -7,12 +7,12 @@ lint: flake
 
 test:
     # Unit testing using pytest
-	py.test --pyargs cloudknot --cov-report term-missing --cov=cloudknot
+	pytest --pyargs cloudknot --cov-report term-missing --cov=cloudknot
 
 devtest:
     # Unit testing with the -x option, aborts testing after first failure
     # Useful for development when tests are long
-	py.test -x --pyargs cloudknot --cov-report term-missing --cov=cloudknot
+	pytest -x --pyargs cloudknot --cov-report term-missing --cov=cloudknot
 
 clean: clean-build clean-pyc ## remove all build, test, coverage and Python artifacts
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
-![Build Status](https://github.com/nrdg/cloudknot/workflows/build/badge.svg)
-[![Codacy Badge](https://app.codacy.com/project/badge/Grade/4a5d0c767bfd4f0eae820c24df1ce2a8)](https://www.codacy.com/gh/nrdg/cloudknot?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=nrdg/cloudknot&amp;utm_campaign=Badge_Grade)
-[![Codacy Badge](https://app.codacy.com/project/badge/Coverage/d6fa3a18646f4a8089c7c897819d0342)](https://www.codacy.com/manual/richford/cloudknot?utm_source=github.com&utm_medium=referral&utm_content=nrdg/cloudknot&utm_campaign=Badge_Coverage)
-
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Build Status](https://github.com/nrdg/cloudknot/workflows/build/badge.svg)](https://github.com/nrdg/cloudknot/workflows/build/badge.svg)
+[![Coverage Status](https://coveralls.io/repos/github/nrdg/cloudknot/badge.svg?branch=master)](https://coveralls.io/github/nrdg/cloudknot?branch=master)
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/4a5d0c767bfd4f0eae820c24df1ce2a8)](https://www.codacy.com/gh/nrdg/cloudknot?utm_source=github.com&utm_medium=referral&utm_content=nrdg/cloudknot&utm_campaign=Badge_Grade)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/python/black)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![DOI](https://zenodo.org/badge/102051437.svg)](https://zenodo.org/badge/latestdoi/102051437)
 
 # cloudknot

--- a/cloudknot/__init__.py
+++ b/cloudknot/__init__.py
@@ -22,7 +22,7 @@ except ModuleNotFoundError:
 
 try:
     __version__ = version(__name__)
-except PackageNotFoundError:
+except PackageNotFoundError:  # pragma: nocover
     # package is not installed
     pass
 
@@ -59,7 +59,7 @@ except OSError as e:
     pre_existing = e.errno == errno.EEXIST and os.path.isdir(logdir)
     if pre_existing:
         pass
-    else:
+    else:  # pragma: nocover
         raise e
 
 handler = logging.FileHandler(logpath, mode="w")

--- a/cloudknot/aws/base_classes.py
+++ b/cloudknot/aws/base_classes.py
@@ -726,7 +726,7 @@ def set_profile(profile_name):
     """
     profile_info = list_profiles()
 
-    if profile_name not in profile_info.profile_names:
+    if not (profile_name in profile_info.profile_names or profile_name == "from-env"):
         raise CloudknotInputError(
             "The profile you specified does not exist in either the AWS "
             "config file at {conf:s} or the AWS shared credentials file at "
@@ -752,7 +752,9 @@ def set_profile(profile_name):
         # throughout the package
         max_pool = clients["iam"].meta.config.max_pool_connections
         boto_config = botocore.config.Config(max_pool_connections=max_pool)
-        session = boto3.Session(profile_name=profile_name)
+        session = boto3.Session(
+            profile_name=profile_name if profile_name != "from-env" else None
+        )
         clients["batch"] = session.client(
             "batch", region_name=get_region(), config=boto_config
         )

--- a/cloudknot/aws/base_classes.py
+++ b/cloudknot/aws/base_classes.py
@@ -591,6 +591,8 @@ def set_region(region="us-east-1"):
         clients["iam"] = session.client("iam", region_name=region, config=boto_config)
         clients["s3"] = session.client("s3", region_name=region, config=boto_config)
 
+    mod_logger.debug("Set region to {region:s}".format(region=region))
+
 
 @registered
 def list_profiles():
@@ -772,6 +774,8 @@ def set_profile(profile_name):
         clients["s3"] = session.client(
             "s3", region_name=get_region(), config=boto_config
         )
+
+    mod_logger.debug("Set profile to {profile:s}".format(profile=profile_name))
 
 
 #: module-level dictionary of boto3 clients for IAM, EC2, Batch, ECR, ECS, S3.

--- a/cloudknot/aws/base_classes.py
+++ b/cloudknot/aws/base_classes.py
@@ -33,14 +33,14 @@ def get_tags(name, additional_tags=None):
     if additional_tags is not None:
         if isinstance(additional_tags, list):
             if not all(
-                [set(item.keys) == set(["Key", "Value"]) for item in additional_tags]
+                [set(item.keys()) == set(["Key", "Value"]) for item in additional_tags]
             ):
                 raise ValueError(
                     "If additional_tags is a list, it must be a list of "
                     "dictionaries of the form {'Key': key_val, 'Value': "
                     "value_val}."
                 )
-            tag_list = additional_tags
+            tag_list += additional_tags
         elif isinstance(additional_tags, dict):
             if "Key" in additional_tags.keys() or "Value" in additional_tags.keys():
                 raise ValueError(

--- a/cloudknot/aws/base_classes.py
+++ b/cloudknot/aws/base_classes.py
@@ -578,7 +578,10 @@ def set_region(region="us-east-1"):
         # throughout the package
         max_pool = clients["iam"].meta.config.max_pool_connections
         boto_config = botocore.config.Config(max_pool_connections=max_pool)
-        session = boto3.Session(profile_name=get_profile(fallback=None))
+        profile_name = get_profile(fallback=None)
+        session = boto3.Session(
+            profile_name=profile_name if profile_name != "from-env" else None
+        )
         clients["batch"] = session.client(
             "batch", region_name=region, config=boto_config
         )

--- a/cloudknot/aws/ecr.py
+++ b/cloudknot/aws/ecr.py
@@ -22,6 +22,22 @@ def registered(fn):
 mod_logger = logging.getLogger(__name__)
 
 
+def _get_repo_info_from_uri(repo_uri):
+    # Get all repositories
+    repositories = clients["ecr"].describe_repositories(maxResults=500)["repositories"]
+
+    _repo_uri = repo_uri.split(":")[0]
+    # Filter by matching on repo_uri
+    matching_repo = [
+        repo for repo in repositories if repo["repositoryUri"] == _repo_uri
+    ][0]
+
+    return {
+        "registry_id": matching_repo["registryId"],
+        "repo_name": matching_repo["repositoryName"],
+    }
+
+
 # noinspection PyPropertyAccess,PyAttributeOutsideInit
 @registered
 class DockerRepo(NamedObject):

--- a/cloudknot/cloudknot.py
+++ b/cloudknot/cloudknot.py
@@ -145,6 +145,9 @@ class Pars(aws.NamedObject):
                     self._stack_id,
                 )
 
+            response = aws.clients["cloudformation"].describe_stacks(
+                StackName=self._stack_id
+            )
             outs = response.get("Stacks")[0]["Outputs"]
 
             self._batch_service_role = _stack_out("BatchServiceRole", outs)
@@ -979,6 +982,9 @@ class Knot(aws.NamedObject):
                     self._stack_id,
                 )
 
+            response = aws.clients["cloudformation"].describe_stacks(
+                StackName=self._stack_id
+            )
             outs = response.get("Stacks")[0]["Outputs"]
 
             job_def_arn = _stack_out("JobDefinition", outs)

--- a/cloudknot/cloudknot.py
+++ b/cloudknot/cloudknot.py
@@ -14,7 +14,7 @@ except ImportError:
 from concurrent.futures import ThreadPoolExecutor
 
 from . import aws
-from .config import get_config_file, rlock
+from .config import get_config_file, rlock, is_valid_stack
 from . import dockerimage
 
 __all__ = []
@@ -129,54 +129,13 @@ class Pars(aws.NamedObject):
 
             self._stack_id = config.get(self._pars_name, "stack-id")
 
-            try:
-                response = aws.clients["cloudformation"].describe_stacks(
-                    StackName=self._stack_id
-                )
-            except aws.clients["cloudformation"].exceptions.ClientError as e:
-                error_code = e.response.get("Error").get("Message")
-                no_stack_code = "Stack with id {0:s} does not exist" "".format(
-                    self._stack_id
-                )
-                if error_code == no_stack_code:
-                    # Remove this section from the config file
-                    with rlock:
-                        config.read(get_config_file())
-                        config.remove_section(self._pars_name)
-                        with open(get_config_file(), "w") as f:
-                            config.write(f)
-                    raise aws.ResourceDoesNotExistException(
-                        "Cloudknot found this PARS in its config file, but "
-                        "the PARS stack that you requested does not exist on "
-                        "AWS. Cloudknot has deleted this PARS from the config "
-                        "file, so you may be able to create a new one simply "
-                        "by re-running your previous command.",
-                        self._stack_id,
-                    )
-                else:  # pragma: nocover
-                    raise e
-
-            no_stack = len(response.get("Stacks")) == 0 or response.get("Stacks")[0][
-                "StackStatus"
-            ] in [
-                "CREATE_FAILED",
-                "ROLLBACK_COMPLETE",
-                "ROLLBACK_IN_PROGRESS",
-                "ROLLBACK_FAILED",
-                "DELETE_IN_PROGRESS",
-                "DELETE_FAILED",
-                "DELETE_COMPLETE",
-                "UPDATE_ROLLBACK_FAILED",
-            ]
-
-            if no_stack:
+            if not is_valid_stack(self._stack_id):
                 # Remove this section from the config file
                 with rlock:
                     config.read(get_config_file())
                     config.remove_section(self._pars_name)
                     with open(get_config_file(), "w") as f:
                         config.write(f)
-
                 raise aws.ResourceDoesNotExistException(
                     "Cloudknot found this PARS in its config file, but "
                     "the PARS stack that you requested does not exist on "
@@ -1005,58 +964,18 @@ class Knot(aws.NamedObject):
 
             self._stack_id = config.get(self._knot_name, "stack-id")
 
-            try:
-                response = aws.clients["cloudformation"].describe_stacks(
-                    StackName=self._stack_id
-                )
-            except aws.clients["cloudformation"].exceptions.ClientError as e:
-                error_code = e.response.get("Error").get("Message")
-                no_stack_code = "Stack with id {0:s} does not exist" "".format(
-                    self._stack_id
-                )
-                if error_code == no_stack_code:
-                    # Remove this section from the config file
-                    with rlock:
-                        config.read(get_config_file())
-                        config.remove_section(self._knot_name)
-                        with open(get_config_file(), "w") as f:
-                            config.write(f)
-                    raise aws.ResourceDoesNotExistException(
-                        "The Knot cloudformation stack that you requested "
-                        "does not exist. Cloudknot has deleted this Knot from "
-                        "the config file, so you may be able to create a new "
-                        "one simply by re-running your previous command.",
-                        self._stack_id,
-                    )
-                else:
-                    raise e
-
-            no_stack = len(response.get("Stacks")) == 0 or response.get("Stacks")[0][
-                "StackStatus"
-            ] in [
-                "CREATE_FAILED",
-                "ROLLBACK_COMPLETE",
-                "ROLLBACK_IN_PROGRESS",
-                "ROLLBACK_FAILED",
-                "DELETE_IN_PROGRESS",
-                "DELETE_FAILED",
-                "DELETE_COMPLETE",
-                "UPDATE_ROLLBACK_FAILED",
-            ]
-
-            if no_stack:
+            if not is_valid_stack(self._stack_id):
                 # Remove this section from the config file
                 with rlock:
                     config.read(get_config_file())
                     config.remove_section(self._knot_name)
                     with open(get_config_file(), "w") as f:
                         config.write(f)
-
                 raise aws.ResourceDoesNotExistException(
-                    "The Knot cloudformation stack that you requested does "
-                    "not exist. Cloudknot has deleted this Knot from the "
-                    "config file, so you may be able to create a new one "
-                    "simply by re-running your previous command.",
+                    "The Knot cloudformation stack that you requested "
+                    "does not exist. Cloudknot has deleted this Knot from "
+                    "the config file, so you may be able to create a new "
+                    "one simply by re-running your previous command.",
                     self._stack_id,
                 )
 

--- a/cloudknot/config.py
+++ b/cloudknot/config.py
@@ -202,12 +202,19 @@ def prune_stacks():
     """
     config_file = get_config_file()
     config = configparser.ConfigParser()
+    old_profile = aws.get_profile()
+    old_region = aws.get_region()
+
     with rlock:
         config.read(config_file)
 
         for section in config.sections():
             if section.split(" ", 1)[0] in ["knot", "pars"]:
                 stack_id = config.get(section, "stack-id")
+                profile = config.get(section, "profile")
+                region = config.get(section, "region")
+                aws.set_profile(profile)
+                aws.set_region(region)
                 if not is_valid_stack(stack_id):
                     # Remove this section from the config file
                     config.remove_section(section)
@@ -217,6 +224,9 @@ def prune_stacks():
 
         with open(config_file, "w") as f:
             config.write(f)
+
+    aws.set_profile(old_profile)
+    aws.set_region(old_region)
 
 
 def prune():

--- a/cloudknot/config.py
+++ b/cloudknot/config.py
@@ -211,6 +211,9 @@ def prune_stacks():
                 if not is_valid_stack(stack_id):
                     # Remove this section from the config file
                     config.remove_section(section)
+                    mod_logger.info(
+                        "Removed {name:s} from your config file.".format(name=section)
+                    )
 
         with open(config_file, "w") as f:
             config.write(f)

--- a/cloudknot/config.py
+++ b/cloudknot/config.py
@@ -66,7 +66,7 @@ def get_config_file():
                 pre_existing = e.errno == errno.EEXIST and os.path.isdir(configdir)
                 if pre_existing:
                     pass
-                else:
+                else:  # pragma: nocover
                     raise e
 
             # If the config file does not exist, create it
@@ -174,7 +174,7 @@ def is_valid_stack(stack_id):
         no_stack_code = "Stack with id {0:s} does not exist" "".format(stack_id)
         if error_code == no_stack_code:
             return False
-        else:
+        else:  # pragma: nocover
             raise e
 
     no_stack = len(response.get("Stacks")) == 0 or response.get("Stacks")[0][
@@ -274,7 +274,7 @@ def prune_repos():
                     or "RepositoryNotFoundException" in message
                 ):
                     remove_repo = True
-                else:
+                else:  # pragma: nocover
                     raise e
 
             if remove_repo:

--- a/cloudknot/config.py
+++ b/cloudknot/config.py
@@ -216,7 +216,9 @@ def prune_stacks():
                 stack_id = config.get(section, "stack-id")
                 profile = config.get(section, "profile")
                 region = config.get(section, "region")
+                print(profile)
                 aws.set_profile(profile)
+                print(region)
                 aws.set_region(region)
                 if not is_valid_stack(stack_id):
                     # Remove this section from the config file

--- a/cloudknot/config.py
+++ b/cloudknot/config.py
@@ -1,4 +1,5 @@
-"""The config module contains functions to maintain the cloudknot config file.
+"""
+The config module contains functions to maintain the cloudknot config file.
 
 This module contains function that other cloudknot objects use to maintain the
 cloudknot config file, including adding resources, removing resources, and
@@ -325,7 +326,7 @@ def prune_batch_jobs():
 def prune():
     """
     Clean unused resources from the config file.
-    
+
     This is a wrapper function for the more resource-specific prune_* functions.
     """
     prune_stacks()

--- a/cloudknot/config.py
+++ b/cloudknot/config.py
@@ -216,9 +216,7 @@ def prune_stacks():
                 stack_id = config.get(section, "stack-id")
                 profile = config.get(section, "profile")
                 region = config.get(section, "region")
-                print(profile)
                 aws.set_profile(profile)
-                print(region)
                 aws.set_region(region)
                 if not is_valid_stack(stack_id):
                     # Remove this section from the config file

--- a/cloudknot/config.py
+++ b/cloudknot/config.py
@@ -1,5 +1,4 @@
-"""
-The config module contains functions to maintain the cloudknot config file.
+"""The config module contains functions to maintain the cloudknot config file.
 
 This module contains function that other cloudknot objects use to maintain the
 cloudknot config file, including adding resources, removing resources, and
@@ -198,7 +197,7 @@ def is_valid_stack(stack_id):
 def prune_stacks():
     """
     Clean unused pars and knots from config file.
-    
+
     Verify that the pars/knot sections in the config file refer to actual
     CloudFormation stacks that exist on AWS. If not, remove from config file.
     """
@@ -311,7 +310,7 @@ def prune_batch_jobs():
         region = section.split(" ")[2]
         aws.set_profile(profile)
         aws.set_region(region)
-        for job_id, job_name in config[section].items():
+        for job_id in config[section].keys():
             response = aws.clients["batch"].describe_jobs(jobs=[job_id])
             if not response.get("jobs"):
                 remove_resource(section, job_id)

--- a/cloudknot/data/config_ref_data/test_add_resource.cfg
+++ b/cloudknot/data/config_ref_data/test_add_resource.cfg
@@ -1,0 +1,10 @@
+[aws]
+configured = True
+
+[test-section-0]
+test-option-0 = test-value
+test-option-1 = test-value
+
+[test-section-1]
+test-option-0 = test-value
+

--- a/cloudknot/data/config_ref_data/test_remove_resource.cfg
+++ b/cloudknot/data/config_ref_data/test_remove_resource.cfg
@@ -1,0 +1,9 @@
+[aws]
+configured = True
+
+[test-section-0]
+test-option-1 = test-value
+
+[test-section-1]
+test-option-0 = test-value
+

--- a/cloudknot/tests/test_aws.py
+++ b/cloudknot/tests/test_aws.py
@@ -158,7 +158,9 @@ def pars(bucket_cleanup):
     p.clobber()
 
 
-def test_get_tags():
+@mock_all
+def test_get_tags(aws_credentials):
+    ck.refresh_clients()
     name = "test-name"
     tags_with_name_only = ck.aws.get_tags(name=name)
     ref_name = {"Key": "Name", "Value": name}

--- a/cloudknot/tests/test_aws.py
+++ b/cloudknot/tests/test_aws.py
@@ -52,9 +52,9 @@ def composed(*decs):
 def aws_credentials():
     """Mocked AWS Credentials for moto."""
     os.environ["AWS_ACCESS_KEY_ID"] = "testing"
-    os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
-    os.environ["AWS_SECURITY_TOKEN"] = "testing"
-    os.environ["AWS_SESSION_TOKEN"] = "testing"
+    os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"  # nosec
+    os.environ["AWS_SECURITY_TOKEN"] = "testing"  # nosec
+    os.environ["AWS_SESSION_TOKEN"] = "testing"  # nosec
 
 
 mock_all = composed(

--- a/cloudknot/tests/test_aws.py
+++ b/cloudknot/tests/test_aws.py
@@ -484,68 +484,48 @@ def test_get_profile(bucket_cleanup):
         ck.refresh_clients()
 
 
-# def test_set_profile(bucket_cleanup):
-#     try:
-#         old_credentials_file = os.environ['AWS_SHARED_CREDENTIALS_FILE']
-#     except KeyError:
-#         old_credentials_file = None
-#
-#     try:
-#         old_aws_config_file = os.environ['AWS_CONFIG_FILE']
-#     except KeyError:
-#         old_aws_config_file = None
-#
-#     try:
-#         old_ck_config_file = os.environ['CLOUDKNOT_CONFIG_FILE']
-#     except KeyError:
-#         old_ck_config_file = None
-#
-#     ref_dir = op.join(data_path, 'profiles_ref_data')
-#     ck_config_file = op.join(ref_dir, 'cloudknot_without_profile')
-#     shutil.copy(ck_config_file, ck_config_file + '.bak')
-#     try:
-#         os.environ['CLOUDKNOT_CONFIG_FILE'] = ck_config_file
-#
-#         config_file = op.join(ref_dir, 'config')
-#         os.environ['AWS_CONFIG_FILE'] = config_file
-#
-#         cred_file = op.join(ref_dir, 'credentials_without_default')
-#         os.environ['AWS_SHARED_CREDENTIALS_FILE'] = cred_file
-#
-#         with pytest.raises(ck.aws.CloudknotInputError):
-#             ck.set_profile(profile_name='not_in_list_of_profiles')
-#
-#         profile = 'name-5'
-#         ck.set_profile(profile_name=profile)
-#         assert ck.get_profile() == profile
-#     finally:
-#         shutil.move(ck_config_file + '.bak', ck_config_file)
-#
-#         if old_credentials_file:
-#             os.environ['AWS_SHARED_CREDENTIALS_FILE'] = old_credentials_file
-#         else:
-#             try:
-#                 del os.environ['AWS_SHARED_CREDENTIALS_FILE']
-#             except KeyError:
-#                 pass
-#
-#         if old_aws_config_file:
-#             os.environ['AWS_CONFIG_FILE'] = old_aws_config_file
-#         else:
-#             try:
-#                 del os.environ['AWS_CONFIG_FILE']
-#             except KeyError:
-#                 pass
-#
-#         if old_ck_config_file:
-#             os.environ['CLOUDKNOT_CONFIG_FILE'] = old_ck_config_file
-#         else:
-#             try:
-#                 del os.environ['CLOUDKNOT_CONFIG_FILE']
-#             except KeyError:
-#                 pass
-#
-#         ck.refresh_clients()
+def test_set_profile(bucket_cleanup):
+    old_credentials_file = os.environ.get("AWS_SHARED_CREDENTIALS_FILE")
+    old_aws_config_file = os.environ.get("AWS_CONFIG_FILE")
+    old_ck_config_file = os.environ.get("CLOUDKNOT_CONFIG_FILE")
+
+    ref_dir = op.join(data_path, "profiles_ref_data")
+    ck_config_file = op.join(ref_dir, "cloudknot_without_profile")
+    shutil.copy(ck_config_file, ck_config_file + ".bak")
+    try:
+        os.environ["CLOUDKNOT_CONFIG_FILE"] = ck_config_file
+
+        config_file = op.join(ref_dir, "config")
+        os.environ["AWS_CONFIG_FILE"] = config_file
+
+        cred_file = op.join(ref_dir, "credentials_without_default")
+        os.environ["AWS_SHARED_CREDENTIALS_FILE"] = cred_file
+
+        with pytest.raises(ck.aws.CloudknotInputError):
+            ck.set_profile(profile_name="not_in_list_of_profiles")
+
+        profile = "name-5"
+        ck.set_profile(profile_name=profile)
+        assert ck.get_profile() == profile
+    finally:
+        shutil.move(ck_config_file + ".bak", ck_config_file)
+
+        if old_credentials_file:
+            os.environ["AWS_SHARED_CREDENTIALS_FILE"] = old_credentials_file
+        else:
+            os.environ.pop("AWS_SHARED_CREDENTIALS_FILE")
+
+        if old_aws_config_file:
+            os.environ["AWS_CONFIG_FILE"] = old_aws_config_file
+        else:
+            os.environ.pop("AWS_CONFIG_FILE")
+
+        if old_ck_config_file:
+            os.environ["CLOUDKNOT_CONFIG_FILE"] = old_ck_config_file
+        else:
+            os.environ.pop("CLOUDKNOT_CONFIG_FILE")
+
+        ck.refresh_clients()
 
 
 @mock_all

--- a/cloudknot/tests/test_config.py
+++ b/cloudknot/tests/test_config.py
@@ -28,9 +28,9 @@ def composed(*decs):
 def aws_credentials():
     """Mocked AWS Credentials for moto."""
     os.environ["AWS_ACCESS_KEY_ID"] = "testing"
-    os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
-    os.environ["AWS_SECURITY_TOKEN"] = "testing"
-    os.environ["AWS_SESSION_TOKEN"] = "testing"
+    os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"  # nosec
+    os.environ["AWS_SECURITY_TOKEN"] = "testing"  # nosec
+    os.environ["AWS_SESSION_TOKEN"] = "testing"  # nosec
 
 
 mock_all = composed(

--- a/cloudknot/tests/test_config.py
+++ b/cloudknot/tests/test_config.py
@@ -1,0 +1,170 @@
+from __future__ import absolute_import, division, print_function
+
+import cloudknot as ck
+import configparser
+import filecmp
+import os
+import os.path as op
+import pytest
+import shutil
+import tempfile
+
+from moto import mock_batch, mock_cloudformation, mock_ec2, mock_ecr
+from moto import mock_ecs, mock_iam, mock_s3
+
+data_path = op.join(ck.__path__[0], "data")
+
+
+def composed(*decs):
+    def deco(f):
+        for dec in reversed(decs):
+            f = dec(f)
+        return f
+
+    return deco
+
+
+@pytest.fixture(scope="module")
+def aws_credentials():
+    """Mocked AWS Credentials for moto."""
+    os.environ["AWS_ACCESS_KEY_ID"] = "testing"
+    os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
+    os.environ["AWS_SECURITY_TOKEN"] = "testing"
+    os.environ["AWS_SESSION_TOKEN"] = "testing"
+
+
+mock_all = composed(
+    mock_ecr, mock_batch, mock_cloudformation, mock_ec2, mock_ecs, mock_iam, mock_s3
+)
+
+
+@pytest.fixture(scope="function")
+def tmp_cfg_dir():
+    old_cfg_file = os.environ.get("CLOUDKNOT_CONFIG_FILE")
+    temp_dir = tempfile.mkdtemp()
+    temp_name = os.path.join(temp_dir, "cloudknot")
+    os.environ["CLOUDKNOT_CONFIG_FILE"] = temp_name
+    yield temp_name
+    shutil.rmtree(temp_dir)
+    if old_cfg_file is None:
+        os.environ.pop("CLOUDKNOT_CONFIG_FILE", None)
+    else:
+        os.environ["CLOUDKNOT_CONFIG_FILE"] = old_cfg_file
+
+
+@pytest.fixture(scope="function")
+def configured(tmp_cfg_dir):
+    tmp_name = tmp_cfg_dir
+    ck.config.add_resource("aws", "configured", "True")
+    yield tmp_name
+
+
+def test_get_config_file(tmp_cfg_dir):
+    temp_name = tmp_cfg_dir
+    temp_cfg_file = ck.config.get_config_file()
+    assert os.path.samefile(temp_cfg_file, temp_name)
+
+    with open(temp_name, "r") as fp:
+        header_text = fp.read()
+
+    assert header_text == "# cloudknot configuration file"
+
+    os.environ.pop("CLOUDKNOT_CONFIG_FILE", None)
+    default_cfg_file = ck.config.get_config_file()
+    home = os.path.expanduser("~")
+    home_cfg_file = os.path.join(home, ".aws", "cloudknot")
+    assert os.path.samefile(default_cfg_file, home_cfg_file)
+
+
+def test_add_remove_verify(configured):
+    temp_name = configured
+
+    ck.config.add_resource("test-section-0", "test-option-0", "test-value")
+    ck.config.add_resource("test-section-0", "test-option-1", "test-value")
+    ck.config.add_resource("test-section-1", "test-option-0", "test-value")
+
+    ref_cfg = os.path.join(data_path, "config_ref_data", "test_add_resource.cfg")
+    assert filecmp.cmp(temp_name, ref_cfg, shallow=False)
+
+    ck.config.remove_resource("test-section-0", "test-option-0")
+    ck.config.remove_resource("no-section-error", "test-option-0")
+    ref_cfg = os.path.join(data_path, "config_ref_data", "test_remove_resource.cfg")
+    assert filecmp.cmp(temp_name, ref_cfg, shallow=False)
+
+    ck.config.verify_sections()
+    with open(temp_name, "r") as fp:
+        aws_config = fp.read()
+
+    assert aws_config == "[aws]\nconfigured = True\n\n"
+
+
+@mock_all
+def test_is_valid_stack(configured, aws_credentials):
+    ck.refresh_clients()
+
+    pars = ck.Pars(name="test-valid-stack")
+    assert ck.config.is_valid_stack(stack_id=pars.stack_id)
+
+    ck.aws.clients["cloudformation"].delete_stack(StackName=pars.stack_id)
+    assert not ck.config.is_valid_stack(stack_id=pars.stack_id)
+
+
+@mock_all
+def test_prune_stacks(configured):
+    config_name = configured
+    ck.refresh_clients()
+
+    pars0 = ck.Pars(name="test-prune-0")
+    pars1 = ck.Pars(name="test-prune-1")
+
+    ck.aws.clients["cloudformation"].delete_stack(StackName=pars0.stack_id)
+    ck.config.prune_stacks()
+
+    config_file = ck.config.get_config_file()
+    config = configparser.ConfigParser()
+    config.read(config_file)
+    assert pars0.pars_name not in config.sections()
+    assert pars1.pars_name in config.sections()
+
+
+@mock_all
+def test_prune_repos(configured):
+    config_name = configured
+    ck.refresh_clients()
+
+    repo0 = ck.aws.DockerRepo(name="test-prune-0")
+    repo1 = ck.aws.DockerRepo(name="test-prune-1")
+    repo2 = ck.aws.DockerRepo(name="test-prune-2")
+
+    ck.aws.clients["ecr"].delete_repository(repositoryName=repo0.name)
+    ck.config.prune_repos()
+
+    config = configparser.ConfigParser()
+    config.read(config_name)
+    repo_section = config[repo0._section_name]
+
+    assert repo0.name not in repo_section
+    assert repo1.name in repo_section
+    assert repo2.name in repo_section
+
+    ck.config.add_resource(repo1._section_name, repo1.name, "0123")
+    ck.config.prune()
+
+    config = configparser.ConfigParser()
+    config.read(config_name)
+    repo_section = config[repo0._section_name]
+
+    assert repo1.name not in repo_section
+    assert repo2.name in repo_section
+
+
+def test_prune_batch_jobs():
+    pass
+
+
+def test_prune_images():
+    pass
+
+
+def test_prune():
+    pass

--- a/cloudknot/tests/test_config.py
+++ b/cloudknot/tests/test_config.py
@@ -110,7 +110,7 @@ def test_is_valid_stack(configured, aws_credentials):
 
 
 @mock_all
-def test_prune_stacks(configured, aws_credentials):
+def test_prune_stacks(configured):
     config_name = configured
     ck.refresh_clients()
 

--- a/cloudknot/tests/test_config.py
+++ b/cloudknot/tests/test_config.py
@@ -110,7 +110,7 @@ def test_is_valid_stack(configured, aws_credentials):
 
 
 @mock_all
-def test_prune_stacks(configured):
+def test_prune_stacks(configured, aws_credentials):
     config_name = configured
     ck.refresh_clients()
 

--- a/cloudknot/tests/test_config.py
+++ b/cloudknot/tests/test_config.py
@@ -120,9 +120,8 @@ def test_prune_stacks(configured):
     ck.aws.clients["cloudformation"].delete_stack(StackName=pars0.stack_id)
     ck.config.prune_stacks()
 
-    config_file = ck.config.get_config_file()
     config = configparser.ConfigParser()
-    config.read(config_file)
+    config.read(config_name)
     assert pars0.pars_name not in config.sections()
     assert pars1.pars_name in config.sections()
 

--- a/cloudknot/tests/test_config.py
+++ b/cloudknot/tests/test_config.py
@@ -110,7 +110,7 @@ def test_is_valid_stack(configured, aws_credentials):
 
 
 @mock_all
-def test_prune_stacks(configured):
+def test_prune_stacks(configured, aws_credentials):
     config_name = configured
     ck.refresh_clients()
 
@@ -127,7 +127,7 @@ def test_prune_stacks(configured):
 
 
 @mock_all
-def test_prune_repos(configured):
+def test_prune_repos(configured, aws_credentials):
     config_name = configured
     ck.refresh_clients()
 
@@ -162,8 +162,4 @@ def test_prune_batch_jobs():
 
 
 def test_prune_images():
-    pass
-
-
-def test_prune():
     pass

--- a/cloudknot/tests/test_docker_image.py
+++ b/cloudknot/tests/test_docker_image.py
@@ -28,9 +28,9 @@ def composed(*decs):
 def aws_credentials():
     """Mocked AWS Credentials for moto."""
     os.environ["AWS_ACCESS_KEY_ID"] = "testing"
-    os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
-    os.environ["AWS_SECURITY_TOKEN"] = "testing"
-    os.environ["AWS_SESSION_TOKEN"] = "testing"
+    os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"  # nosec
+    os.environ["AWS_SECURITY_TOKEN"] = "testing"  # nosec
+    os.environ["AWS_SESSION_TOKEN"] = "testing"  # nosec
 
 
 mock_all = composed(

--- a/cloudknot/tests/test_knot.py
+++ b/cloudknot/tests/test_knot.py
@@ -24,9 +24,9 @@ def composed(*decs):
 def aws_credentials():
     """Mocked AWS Credentials for moto."""
     os.environ["AWS_ACCESS_KEY_ID"] = "testing"
-    os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
-    os.environ["AWS_SECURITY_TOKEN"] = "testing"
-    os.environ["AWS_SESSION_TOKEN"] = "testing"
+    os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"  # nosec
+    os.environ["AWS_SECURITY_TOKEN"] = "testing"  # nosec
+    os.environ["AWS_SESSION_TOKEN"] = "testing"  # nosec
 
 
 mock_all = composed(

--- a/cloudknot/tests/test_pars.py
+++ b/cloudknot/tests/test_pars.py
@@ -23,9 +23,9 @@ def composed(*decs):
 def aws_credentials():
     """Mocked AWS Credentials for moto."""
     os.environ["AWS_ACCESS_KEY_ID"] = "testing"
-    os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
-    os.environ["AWS_SECURITY_TOKEN"] = "testing"
-    os.environ["AWS_SESSION_TOKEN"] = "testing"
+    os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"  # nosec
+    os.environ["AWS_SECURITY_TOKEN"] = "testing"  # nosec
+    os.environ["AWS_SESSION_TOKEN"] = "testing"  # nosec
 
 
 mock_all = composed(


### PR DESCRIPTION
Resolves #8 
Resolves #11 

This PR introduces some functions in `cloudknot.config` to "prune" config file entries. In this context, "prune" means to remove any config entries that do not refer to existing resources on AWS. We will provide pruning for

- [x] `Pars`
- [x] `Knot`
- [x] `DockerRepo`
- [x] `BatchJob`
- [x] `DockerImage`

This is related to #136, but does not resolve that issue. I think we should provide a CLI in another PR. This also does not solve the problem of removing unwanted resources that ***ARE*** on AWS. I'm thinking that we could do that through an interactive CLI but I'll add more details to #136 and limit the scope of this PR to config pruning through a Python API.