### PR TITLE
FIX: Require object names to conform to AWS URI regex

### DIFF
--- a/cloudknot/aws/base_classes.py
+++ b/cloudknot/aws/base_classes.py
@@ -1065,8 +1065,8 @@ class NamedObject(object):
         Parameters
         ----------
         name : string
-            Name of the object. Must satisfy regular expression
-            pattern: [a-zA-Z][-a-zA-Z0-9]*
+            Name of the object.
+            Must satisfy regular expression pattern: [a-zA-Z][-a-zA-Z0-9]*
         """
         config_file = get_config_file()
         conf = configparser.ConfigParser()
@@ -1080,11 +1080,12 @@ class NamedObject(object):
             ):
                 raise CloudknotConfigurationError(config_file)
 
-        name = str(name).replace("_", "-")
-        pattern = re.compile("[a-zA-Z][-a-zA-Z0-9]*")
+        pattern = re.compile("^[a-zA-Z][-a-zA-Z0-9]*$")
         if not pattern.match(name):
             raise CloudknotInputError(
-                "name must satisfy regular expression " "pattern: [a-zA-Z][-a-zA-Z0-9]*"
+                "We use name in AWS resource identifiers so it must "
+                "satisfy the regular expression pattern: [a-zA-Z][-a-zA-Z0-9]*"
+                " (note that underscores are not allowed)."
             )
 
         self._name = name

--- a/cloudknot/aws/batch.py
+++ b/cloudknot/aws/batch.py
@@ -138,7 +138,8 @@ class BatchJob(NamedObject):
             The AWS jobID, if requesting a job that already exists
 
         name : string
-            Name of the job
+            Name of the job.
+            Must satisfy regular expression pattern: [a-zA-Z][-a-zA-Z0-9]*
 
         job_queue : string
             Job queue ARN specifying the job queue to which this job

--- a/cloudknot/aws/ecr.py
+++ b/cloudknot/aws/ecr.py
@@ -55,7 +55,8 @@ class DockerRepo(NamedObject):
         Parameters
         ----------
         name : str
-            Name of the remote repository
+            Name of the remote repository.
+            Must satisfy regular expression pattern: [a-zA-Z][-a-zA-Z0-9]*
 
         aws_resource_tags : dict or list of dicts
             Additional AWS resource tags to apply to this repository

--- a/cloudknot/cloudknot.py
+++ b/cloudknot/cloudknot.py
@@ -65,6 +65,7 @@ class Pars(aws.NamedObject):
             The name of this PARS. If `pars name` exists in the config file,
             Pars will retrieve those PARS resource parameters. Otherwise,
             Pars will create a new PARS with this name.
+            Must satisfy regular expression pattern: [a-zA-Z][-a-zA-Z0-9]*
             Default: '${AWS-username}-default'
 
         batch_service_role_name : str
@@ -725,7 +726,8 @@ class Knot(aws.NamedObject):
         Parameters
         ----------
         name : str, optional
-            The name for this knot
+            The name for this knot.
+            Must satisfy regular expression pattern: [a-zA-Z][-a-zA-Z0-9]*
             Default='${AWS-username}-default'
 
         pars : Pars, optional

--- a/cloudknot/data/docker_reqs_ref_data/py2/ref2/Dockerfile
+++ b/cloudknot/data/docker_reqs_ref_data/py2/ref2/Dockerfile
@@ -1,5 +1,5 @@
 ###############################################################################
-# Dockerfile to build test-func-input.py application container
+    # Dockerfile to build test-func-input application container
 # Based on python:2
 ###############################################################################
 

--- a/cloudknot/data/docker_reqs_ref_data/py3/ref2/Dockerfile
+++ b/cloudknot/data/docker_reqs_ref_data/py3/ref2/Dockerfile
@@ -1,5 +1,5 @@
 ###############################################################################
-# Dockerfile to build test-func-input.py application container
+# Dockerfile to build test-func-input application container
 # Based on python:3
 ###############################################################################
 

--- a/cloudknot/dockerimage.py
+++ b/cloudknot/dockerimage.py
@@ -75,7 +75,8 @@ class DockerImage(aws.NamedObject):
         ----------
         name : str
             Name of DockerImage, only used to retrieve DockerImage from
-            config file info. Do not use to create new DockerImage
+            config file info. Do not use to create new DockerImage.
+            Must satisfy regular expression pattern: [a-zA-Z][-a-zA-Z0-9]*
 
         func : function
             Python function to be dockerized
@@ -271,7 +272,9 @@ class DockerImage(aws.NamedObject):
 
                 self._script_path = os.path.abspath(script_path)
                 super(DockerImage, self).__init__(
-                    name=os.path.basename(self.script_path)
+                    name=os.path.splitext(os.path.basename(self.script_path))[0]
+                    .replace("_", "-")
+                    .replace(".", "-")
                 )
 
                 # Set the parent directory
@@ -286,7 +289,9 @@ class DockerImage(aws.NamedObject):
                 # We will create the script, Dockerfile, and requirements.txt
                 # in a new directory
                 self._clobber_script = True
-                super(DockerImage, self).__init__(name=name if name else func.__name__)
+                super(DockerImage, self).__init__(
+                    name=name if name else func.__name__.replace("_", "-")
+                )
 
                 if dir_name:
                     self._build_path = os.path.abspath(dir_name)

--- a/cloudknot/tests/test_aws.py
+++ b/cloudknot/tests/test_aws.py
@@ -67,11 +67,14 @@ data_path = op.join(ck.__path__[0], "data")
 
 
 def test_NamedObject():
-    named = ck.aws.NamedObject(name="test_test")
+    named = ck.aws.NamedObject(name="test-test")
     assert named.name == "test-test"
 
     with pytest.raises(ck.aws.CloudknotInputError):
         ck.aws.NamedObject(name="42test")
+
+    with pytest.raises(ck.aws.CloudknotInputError):
+        ck.aws.NamedObject(name="test_test")
 
 
 def get_testing_name():

--- a/cloudknot/tests/test_docker_image.py
+++ b/cloudknot/tests/test_docker_image.py
@@ -333,7 +333,7 @@ def test_DockerImage(cleanup_repos):
             script_path=script_path, dir_name=dir_name, username="unit-test-username"
         )
 
-        assert di.name == op.basename(script_path)
+        assert di.name == op.splitext(op.basename(script_path))[0].replace("_", "-")
         import_names = set([d["name"] for d in di.pip_imports])
         assert import_names == correct_pip_imports
         assert di.missing_imports == []


### PR DESCRIPTION
Resolves #256 
Resolves #258 

This PR requires object names to conform to the AWS URI regex. Previously, underscores were silently converted to dashes and then checked for regex compliance, which caused user confusion. Now, we simply throw an error when the name doesn't comply and simply a more helpful error message.

I also fixed the regex so that it must match on the entire `name` string instead of just the beginning.

Lastly, I fixed a bug in which `DockerImage` was adding `.py` onto it's name which generated from an existing script.