### PR TITLE
Pin python sdk for docker version.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ install_requires =
     boto3>=1.5.21
     botocore>=1.8.36
     cloudpickle
-    docker>=3.0.0
+    docker==3.0.0
     pipreqs
     six
     tenacity


### PR DESCRIPTION
This is to see whether newer versions of this library are
the source of errors raised in #268.