### PR TITLE
Fix #309 by explicitly making script executable within the Docker container

### DIFF
--- a/cloudknot/data/docker_reqs_ref_data/py3/ref1/Dockerfile
+++ b/cloudknot/data/docker_reqs_ref_data/py3/ref1/Dockerfile
@@ -19,6 +19,9 @@ RUN groupadd -f staff \
 # Copy the python script
 COPY --chown="cloudknot-user" "unit-testing-func.py" "/home/cloudknot-user/"
 
+# Make the python script executable
+RUN chmod +x "/home/cloudknot-user/unit-testing-func.py"
+
 # Set user
 USER "cloudknot-user"
 

--- a/cloudknot/data/docker_reqs_ref_data/py3/ref2/Dockerfile
+++ b/cloudknot/data/docker_reqs_ref_data/py3/ref2/Dockerfile
@@ -19,6 +19,9 @@ RUN groupadd -f staff \
 # Copy the python script
 COPY --chown="unit-test-username" "test-func-input.py" "/home/unit-test-username/"
 
+# Make the python script executable
+RUN chmod +x "/home/unit-test-username/test-func-input.py"
+
 # Set user
 USER "unit-test-username"
 

--- a/cloudknot/templates/Dockerfile.template
+++ b/cloudknot/templates/Dockerfile.template
@@ -19,6 +19,9 @@ RUN groupadd -f staff \
 # Copy the python script
 COPY --chown="${username}" "${script_base_name}" "/home/${username}/"
 
+# Make the python script executable
+RUN chmod +x "/home/${username}/${script_base_name}"
+
 # Set user
 USER "${username}"
 


### PR DESCRIPTION
In #309 the container would not start correctly if the source script was not marked executable. This adds `chmod +x` in the Dockerfile explicitly to ensure that it is.

This did not show up in tests because the source script used for testing was marked executable.
